### PR TITLE
Capture errors during "nuxt generate"

### DIFF
--- a/lib/sentry.js
+++ b/lib/sentry.js
@@ -53,6 +53,9 @@ module.exports = function sentry (moduleOptions) {
   if (this.nuxt.hook) {
     this.nuxt.hook('render:setupMiddleware', app => app.use(Raven.requestHandler()))
     this.nuxt.hook('render:errorMiddleware', app => app.use(Raven.errorHandler()))
+    this.nuxt.hook('generate:routeFailed', ({ route, errors}) => {
+      errors.forEach( ({ error }) => Raven.captureException(error, { extra: { route: route }} ))
+    })
   } else {
     this.nuxt.plugin('renderer', renderer => {
       renderer.app.use(Raven.requestHandler())

--- a/lib/sentry.js
+++ b/lib/sentry.js
@@ -54,7 +54,7 @@ module.exports = function sentry (moduleOptions) {
     this.nuxt.hook('render:setupMiddleware', app => app.use(Raven.requestHandler()))
     this.nuxt.hook('render:errorMiddleware', app => app.use(Raven.errorHandler()))
     this.nuxt.hook('generate:routeFailed', ({ route, errors}) => {
-      errors.forEach( ({ error }) => Raven.captureException(error, { extra: { route: route }} ))
+      errors.forEach( ({ error }) => Raven.captureException(error, { extra: { route }} ))
     })
   } else {
     this.nuxt.plugin('renderer', renderer => {


### PR DESCRIPTION
I noticed that exceptions that were thrown during `nuxt generate` were not being captured.  This adds a hook during `generate:routeFailed` and forwards the errors to Sentry.