### PR TITLE
Added a fallback to deprecated DSN

### DIFF
--- a/lib/sentry.js
+++ b/lib/sentry.js
@@ -29,7 +29,11 @@ module.exports = function sentry (moduleOptions) {
   // Generate DSN
   // https://docs.sentry.io/quickstart/#about-the-dsn
   if (!options.dsn || !options.dsn.length) {
-    options.dsn = `${options.protocol}://${options.public_key}:${options.private_key}@${options.host}${options.path}${options.project_id}`
+    if (!options.private_key || !options.private_key.length) {
+      options.dsn = `${options.protocol}://${options.public_key}@${options.host}${options.path}${options.project_id}`
+    } else {
+      options.dsn = `${options.protocol}://${options.public_key}:${options.private_key}@${options.host}${options.path}${options.project_id}`
+    }
   }
 
   // Public DSN (without private key)


### PR DESCRIPTION
The DNS with the private key is deprecated according the Sentry documentation https://docs.sentry.io/clients/node/config/#environment-variables.

This PR add a verification, if the private_key was informed so use it if not use the new DSN format