### PR TITLE
feat: Add new option "disabled"

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Will be ignored if `dsn` provided.
 
 Will be ignored if `dsn` provided.
 
+### disabled
+- Type: `Boolean`
+  - Default: `process.env.SENTRY_DISABLED || false`
+
 ### disableClientSide
 - Type: `Boolean`
   - Default: `process.env.SENTRY_DISABLE_CLIENT_SIDE || false`

--- a/lib/sentry.js
+++ b/lib/sentry.js
@@ -6,6 +6,7 @@ const logger = require('consola').withScope('nuxt:sentry')
 module.exports = function sentry (moduleOptions) {
   // Merge options
   const options = Object.assign({
+    disabled: process.env.SENTRY_DISABLED || false,
     disableClientSide: process.env.SENTRY_DISABLE_CLIENT_SIDE === 'true' || false,
     dsn: process.env.SENTRY_DSN || null,
     public_dsn: process.env.SENTRY_PUBLIC_DSN || null,
@@ -19,6 +20,11 @@ module.exports = function sentry (moduleOptions) {
       environment: this.options.dev ? 'development' : 'production'
     }
   }, this.options.sentry, moduleOptions)
+
+  // Don't proceed if it's disabled
+  if (this.options.disabled) {
+    return
+  }
 
   // Don't proceed if no keys are provided
   if (!options.dsn && !options.public_key && !options.private_key) {


### PR DESCRIPTION
This PR adds a new option "disabled" to completely disable error capturing for both client/server. This might be useful they're not needed in the development env.