### PR TITLE
Fix checking the option 'disabled'

### DIFF
--- a/lib/sentry.js
+++ b/lib/sentry.js
@@ -22,7 +22,7 @@ module.exports = function sentry (moduleOptions) {
   }, this.options.sentry, moduleOptions)
 
   // Don't proceed if it's disabled
-  if (this.options.disabled) {
+  if (options.disabled) {
     logger.info('Disabled because the disabled option is set')
     return
   }


### PR DESCRIPTION
Option `disabled` with `true` value is ignored because of bug in the module.
This PR fixes it.