### PR TITLE
client side ssr on/off option

### DIFF
--- a/lib/sentry.js
+++ b/lib/sentry.js
@@ -8,6 +8,7 @@ module.exports = function sentry (moduleOptions) {
   const options = Object.assign({
     disabled: process.env.SENTRY_DISABLED || false,
     disableClientSide: process.env.SENTRY_DISABLE_CLIENT_SIDE === 'true' || false,
+    clientSideSsr: (process.env.SENTRY_DISABLE_CLIENT_SIDE !== 'true' && process.env.SENTRY_CLIENT_SIDE_SSR === 'true') || false,
     dsn: process.env.SENTRY_DSN || null,
     public_key: process.env.SENTRY_PUBLIC_KEY || null,
     host: process.env.SENTRY_HOST || 'sentry.io',
@@ -46,7 +47,7 @@ module.exports = function sentry (moduleOptions) {
     this.addPlugin({
       src: path.resolve(__dirname, 'templates/sentry-client.js'),
       fileName: 'sentry-client.js',
-      ssr: false,
+      ssr: options.clientSideSsr,
       options
     })
   }


### PR DESCRIPTION
Hey!
Can we provide option to chose ssr mode when register the client plugin?
It's will be realy helpful when we want to use $sentry incide our custom plugins.
For example like this https://www.dropbox.com/s/huzghaz4anju1ls/Screenshot%202018-11-13%2013.31.49.png?dl=0