### PR TITLE
Add browser default integrations back

### DIFF
--- a/lib/templates/sentry-client.js
+++ b/lib/templates/sentry-client.js
@@ -4,6 +4,15 @@ import * as Sentry from '@sentry/browser'
 export default function (ctx, inject) {
   const opts = Object.assign({}, <%= serialize(options.config) %>, {
     integrations: (integrations) => {
+      integrations.push(new Sentry.Integrations.Dedupe)
+      integrations.push(new Sentry.Integrations.FunctionToString)
+      integrations.push(new Sentry.Integrations.InboundFilters)
+      integrations.push(new Sentry.Integrations.Breadcrumbs)
+      integrations.push(new Sentry.Integrations.GlobalHandlers)
+      integrations.push(new Sentry.Integrations.LinkedErrors)
+      integrations.push(new Sentry.Integrations.ReportingObserver)
+      integrations.push(new Sentry.Integrations.TryCatch)
+      integrations.push(new Sentry.Integrations.UserAgent)
       integrations.push(new Sentry.Integrations.Vue({ Vue }))
       return integrations
     }

--- a/lib/templates/sentry-client.js
+++ b/lib/templates/sentry-client.js
@@ -3,19 +3,19 @@ import * as Sentry from '@sentry/browser'
 
 export default function (ctx, inject) {
   const opts = Object.assign({}, <%= serialize(options.config) %>, {
-    integrations: (integrations) => {
-      integrations.push(new Sentry.Integrations.Dedupe)
-      integrations.push(new Sentry.Integrations.FunctionToString)
-      integrations.push(new Sentry.Integrations.InboundFilters)
-      integrations.push(new Sentry.Integrations.Breadcrumbs)
-      integrations.push(new Sentry.Integrations.GlobalHandlers)
-      integrations.push(new Sentry.Integrations.LinkedErrors)
-      integrations.push(new Sentry.Integrations.ReportingObserver)
-      integrations.push(new Sentry.Integrations.TryCatch)
-      integrations.push(new Sentry.Integrations.UserAgent)
-      integrations.push(new Sentry.Integrations.Vue({ Vue }))
-      return integrations
-    }
+    // Use default browser integrations
+    defaultIntegrations: false,
+    integrations: [
+      new Sentry.Integrations.Dedupe,
+      new Sentry.Integrations.InboundFilters,
+      new Sentry.Integrations.FunctionToString,
+      new Sentry.Integrations.TryCatch,
+      new Sentry.Integrations.Breadcrumbs,
+      new Sentry.Integrations.GlobalHandlers,
+      new Sentry.Integrations.LinkedErrors,
+      new Sentry.Integrations.UserAgent,
+      new Sentry.Integrations.Vue({ Vue })
+    ]
   })
   Sentry.init(opts)
 


### PR DESCRIPTION
Adds default integrations back in (such as user agent and breadcrumb info), which are unset in the new Sentry SDK when `integrations` is set explicitly. Resolves https://github.com/nuxt-community/sentry-module/issues/43. Further reference: https://github.com/getsentry/sentry-javascript/issues/1764