### PR TITLE
Make sentry disabled if it's not in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Will be ignored if `dsn` provided.
 
 ### disabled
 - Type: `Boolean`
-  - Default: `process.env.SENTRY_DISABLED || false`
+  - Default: `process.env.SENTRY_DISABLED || process.env.NODE_ENV !== 'production'`
 
 ### disableClientSide
 - Type: `Boolean`

--- a/lib/sentry.js
+++ b/lib/sentry.js
@@ -6,7 +6,7 @@ const logger = require('consola').withScope('nuxt:sentry')
 module.exports = function sentry (moduleOptions) {
   // Merge options
   const options = Object.assign({
-    disabled: process.env.SENTRY_DISABLED || false,
+    disabled: process.env.SENTRY_DISABLED || process.env.NODE_ENV !== 'production',
     disableClientSide: process.env.SENTRY_DISABLE_CLIENT_SIDE === 'true' || false,
     dsn: process.env.SENTRY_DSN || null,
     public_key: process.env.SENTRY_PUBLIC_KEY || null,


### PR DESCRIPTION
I think it's good to have default disabled value to true when it's not in production environment.