### PR TITLE
checking should be for options.dsn and not options.config.dsn

### DIFF
--- a/lib/sentry.js
+++ b/lib/sentry.js
@@ -23,7 +23,7 @@ module.exports = function sentry (moduleOptions) {
   }
 
   // Initialize Sentry
-  if (!options.disabled && options.config.dsn) {
+  if (!options.disabled && options.dsn) {
     Sentry.init({
       ...options.dsn,
       ...options.config


### PR DESCRIPTION
Sentry for server is not initialized since the check is done on options.config.dsn. It should be done on options.dsn.  