### PR TITLE
Fix: disabled option does not work (#51)

### DIFF
--- a/lib/sentry.js
+++ b/lib/sentry.js
@@ -16,10 +16,12 @@ module.exports = function sentry (moduleOptions) {
 
   if (options.disabled) {
     logger.info('Errors will not be logged because the disable option has been set')
+    return
   }
 
   if (!options.dsn) {
     logger.info('Errors will not be logged because no DSN has been provided')
+    return
   }
 
   // Initialize Sentry


### PR DESCRIPTION
'return' disappeared at this commit. So it does not work.
https://github.com/nuxt-community/sentry-module/commit/31d3db941ab79cf79d52e30d2986f0fe373a0f8b#diff-e6ee66530234110522eee8b87cee6b9f