### PR TITLE
Fixed option object name

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Normally setting required DSN information would be enough.
 - Type: `Boolean`
   - Default: `process.env.SENTRY_DISABLE_CLIENT_SIDE || false`
   
-### options
+### config
 - Type: `Object`
   - Default: `{}`
 


### PR DESCRIPTION
The key name of option which pass to `Sentry.init` should be `config`.