### PR TITLE
Fix: @sentry/webpack-plugin dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
   "dependencies": {
     "@sentry/browser": "^4.5.1",
     "@sentry/node": "^4.5.1",
+    "@sentry/webpack-plugin": "^1.6.2",
     "consola": "^2.3.2"
   },
   "peerDependencies": {
     "nuxt": "<1.0.0 || >1.2.1"
   },
   "devDependencies": {
-    "@sentry/webpack-plugin": "^1.6.2",
     "eslint": "^5.12.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.14.0",


### PR DESCRIPTION
@sentry/webpack-plugin is required as a dependency but is currently listed under devDependencies.