### PR TITLE
fix: sentry init params

### DIFF
--- a/lib/sentry.js
+++ b/lib/sentry.js
@@ -25,8 +25,8 @@ module.exports = function sentry (moduleOptions) {
   }
 
   const options = Object.assign({}, defaults, this.options.sentry, moduleOptions)
-  options.config = Object.assign({}, defaults.config, this.options.sentry.config, moduleOptions.config)
-  options.webpackConfig = Object.assign({}, defaults.webpackConfig, this.options.sentry.webpackConfig, moduleOptions.webpackConfig)
+  options.config = Object.assign({}, defaults.config, this.options.sentry && this.options.sentry.config, moduleOptions.config)
+  options.webpackConfig = Object.assign({}, defaults.webpackConfig, this.options.sentry && this.options.sentry.webpackConfig, moduleOptions.webpackConfig)
 
   if (options.disabled) {
     logger.info('Errors will not be logged because the disable option has been set')
@@ -41,7 +41,7 @@ module.exports = function sentry (moduleOptions) {
   // Initialize Sentry
   if (!options.disabled && options.dsn) {
     Sentry.init({
-      ...options.dsn,
+      dsn: options.dsn,
       ...options.config
     })
     logger.success('Started logging errors to Sentry')


### PR DESCRIPTION
It fixes initialization on a server 🚑

```
{
   ...options.dsn,
   ...options.config
}
```
options.dsn is a string. spread causes incorrect options passing into sentry. 
```
{                                                                 
  '0': 'h',
  '1': 't',
  '2': 't',
  ...
  '58': '3',
  environment: 'development'
}
```