### PR TITLE
fix: fix module options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 The module enables error logging through [Sentry](http://sentry.io).
 
-- **Please note** that version 2.2.0 of this package removed the older `public_key` and `private_key` options, since the updated Sentry packages don't support these anymore. 
+- **Please note** that version 2.2.0 of this package removed the older `public_key` and `private_key` options, since the updated Sentry packages don't support these anymore.
 - **Please note** that version 2.0.0 of this package introduces a breaking change. See [#30](https://github.com/nuxt-community/sentry-module/pull/30) for more information.
 
 ## Setup
@@ -49,13 +49,13 @@ where `this` is a Vue instance.
 
 ## Options
 
-Options can be passed using either environment variables or `sentry` section in `nuxt.config.js`. 
+Options can be passed using either environment variables or `sentry` section in `nuxt.config.js`.
 Normally setting required DSN information would be enough.
 
 ### dsn
 - Type: `String`
   - Default: `process.env.SENTRY_DSN || false`
-  - If no `dsn` is provided, Sentry will be initialised, but errors will not be logged. See [#47](https://github.com/nuxt-community/sentry-module/issues/47) for more information about this. 
+  - If no `dsn` is provided, Sentry will be initialised, but errors will not be logged. See [#47](https://github.com/nuxt-community/sentry-module/issues/47) for more information about this.
 
 ### disabled
 - Type: `Boolean`
@@ -65,13 +65,13 @@ Normally setting required DSN information would be enough.
 ### disableClientSide
 - Type: `Boolean`
   - Default: `process.env.SENTRY_DISABLE_CLIENT_SIDE || false`
-  
+
 ### publishRelease
 - Type: `Boolean`
   - Default: `process.env.SENTRY_PUBLISH_RELEASE || false`
   - See https://docs.sentry.io/workflow/releases for more information
-  
-### options
+
+### config
 - Type: `Object`
   - Default: `{}`
 

--- a/lib/sentry.js
+++ b/lib/sentry.js
@@ -39,13 +39,11 @@ module.exports = function sentry (moduleOptions) {
   }
 
   // Initialize Sentry
-  if (!options.disabled && options.dsn) {
-    Sentry.init({
-      dsn: options.dsn,
-      ...options.config
-    })
-    logger.success('Started logging errors to Sentry')
-  }
+  Sentry.init({
+    dsn: options.dsn,
+    ...options.config
+  })
+  logger.success('Started logging errors to Sentry')
 
   // Enable publishing of sourcemaps
   this.extendBuild((config, { isClient, isDev }) => {

--- a/lib/sentry.js
+++ b/lib/sentry.js
@@ -3,6 +3,7 @@ const path = require('path')
 const logger = require('consola').withScope('nuxt:sentry')
 const Sentry = require('@sentry/node')
 const WebpackPlugin = require('@sentry/webpack-plugin')
+const deepMerge = require('deepmerge')
 
 module.exports = function sentry (moduleOptions) {
   const defaults = {
@@ -24,9 +25,8 @@ module.exports = function sentry (moduleOptions) {
     }
   }
 
-  const options = Object.assign({}, defaults, this.options.sentry, moduleOptions)
-  options.config = Object.assign({}, defaults.config, this.options.sentry.config, moduleOptions.config)
-  options.webpackConfig = Object.assign({}, defaults.webpackConfig, this.options.sentry.webpackConfig, moduleOptions.webpackConfig)
+  const topLevelOptions = this.options.sentry || {}
+  const options = deepMerge.all([defaults, topLevelOptions, moduleOptions])
 
   if (options.disabled) {
     logger.info('Errors will not be logged because the disable option has been set')
@@ -41,7 +41,7 @@ module.exports = function sentry (moduleOptions) {
   // Initialize Sentry
   if (!options.disabled && options.dsn) {
     Sentry.init({
-      ...options.dsn,
+      dsn: options.dsn,
       ...options.config
     })
     logger.success('Started logging errors to Sentry')

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "@sentry/browser": "^4.5.1",
     "@sentry/node": "^4.5.1",
     "@sentry/webpack-plugin": "^1.6.2",
-    "consola": "^2.3.2"
+    "consola": "^2.3.2",
+    "deepmerge": "^3.2.0"
   },
   "peerDependencies": {
     "nuxt": "<1.0.0 || >1.2.1"

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     ]
   },
   "dependencies": {
-    "@sentry/browser": "^4.5.1",
-    "@sentry/node": "^4.5.1",
+    "@sentry/browser": "^4.6.6",
+    "@sentry/node": "^4.6.6",
     "@sentry/webpack-plugin": "^1.6.2",
     "consola": "^2.3.2",
     "deepmerge": "^3.2.0"
@@ -44,11 +44,11 @@
     "nuxt": "<1.0.0 || >1.2.1"
   },
   "devDependencies": {
-    "eslint": "^5.12.0",
+    "eslint": "^5.16.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-node": "^8.0.1",
-    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-promise": "^4.1.1",
     "eslint-plugin-standard": "^4.0.0",
     "eslint-plugin-vue": "^5.1.0"
   }


### PR DESCRIPTION
With no top level 'sentry' object defined in nuxt-config.js, the code
would try to access property of undefined object as
this.options.sentry is undefined. Fixed by using deepmerge package which
both fixes the problem and makes code cleaner.

Also fixed problem with merging dsn property value with the object.
As dsn value is a string, don't use ... on it as that would turn string
into an array of letters.