### PR TITLE
Add option to enable ssr

### DIFF
--- a/lib/sentry.js
+++ b/lib/sentry.js
@@ -9,6 +9,7 @@ module.exports = function sentry (moduleOptions) {
     dsn: process.env.SENTRY_DSN || false,
     disabled: process.env.SENTRY_DISABLED || false,
     disableClientSide: process.env.SENTRY_DISABLE_CLIENT_SIDE || false,
+    enableSsr: process.env.SENTRY_ENABLE_SSR || false,
     publishRelease: process.env.SENTRY_PUBLISH_RELEASE || false,
     config: {
       environment: this.options.dev ? 'development' : 'production'
@@ -61,7 +62,7 @@ module.exports = function sentry (moduleOptions) {
     this.addPlugin({
       src: path.resolve(__dirname, 'templates/sentry-client.js'),
       fileName: 'sentry-client.js',
-      ssr: false,
+      ssr: options.enableSsr,
       options: {
         dsn: options.dsn,
         ...options.config


### PR DESCRIPTION
Related to these issues: #19, #33 
Now it is not possible to log errors from **asyncData** or **nuxtServerInit** without some hacks as described in issues above.

Why we can't just add an option to enable/disable the plugin for server-side? Seems like it works just fine and we can (if `ssr: true`)
```javascript
asyncData(ctx) {
  try {
    const = await api.request()
  } catch (error) {
    ctx.app.$sentry.captureException(error)
  }
}
```