### PR TITLE
fix(client): client not being initialized

### DIFF
--- a/lib/sentry.client.js
+++ b/lib/sentry.client.js
@@ -2,7 +2,7 @@ import VueLib from 'vue'
 import * as Sentry from '@sentry/browser'
 import { <%= Object.keys(options.integrations).map(integration => integration).join(', ') %> } from '@sentry/integrations'
 
-export default function(ctx, inject) {
+export default function (ctx, inject) {
   const opts = Object.assign({}, <%= serialize(options.config) %>, {
     integrations: [
       <%= Object.keys(options.integrations).map(name => {
@@ -16,9 +16,8 @@ export default function(ctx, inject) {
     ]
   })
 
-  if (<%= serialize(options.initialize) %>) {
-    Sentry.init(opts)
-  }
+  <%= if (options.initialize) %>) { %>// Initialize sentry
+  Sentry.init(opts)<% } %>
 
   // Inject Sentry to the context as $sentry
   inject('sentry', Sentry)

--- a/lib/sentry.client.js
+++ b/lib/sentry.client.js
@@ -2,7 +2,7 @@ import VueLib from 'vue'
 import * as Sentry from '@sentry/browser'
 import { <%= Object.keys(options.integrations).map(integration => integration).join(', ') %> } from '@sentry/integrations'
 
-export default function (ctx, inject) {
+export default function(ctx, inject) {
   const opts = Object.assign({}, <%= serialize(options.config) %>, {
     integrations: [
       <%= Object.keys(options.integrations).map(name => {
@@ -16,7 +16,7 @@ export default function (ctx, inject) {
     ]
   })
 
-  if (opts.initialize) {
+  if (<%= serialize(options.initialize) %>) {
     Sentry.init(opts)
   }
 


### PR DESCRIPTION
On the `sentry.client.js`
https://github.com/nuxt-community/sentry-module/blob/42d70b0485054d46f2bf430a4b64244f96fe8b66/lib/sentry.client.js#L19
will never be true since `initialize` is not a property of `options.config` as seen here
https://github.com/nuxt-community/sentry-module/blob/42d70b0485054d46f2bf430a4b64244f96fe8b66/lib/module.js#L86-L94

So the simplest solution, without having to modify any other parts of the codes than the line itself is to convert the if condition to a serialized template and referencing `options.initialize` instead of `opts.initialize`

```
if (<%= serialize(options.initialize) %>) {
    Sentry.init(opts)
}
```


Signed-off-by: Uni Sayo <unibtc@gmail.com>