### PR TITLE
Use officially supported devtool value

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -135,7 +135,7 @@ module.exports = function sentry (moduleOptions) {
       return
     }
     if (isClient) {
-      config.devtool = '#sourcemap'
+      config.devtool = 'source-map'
     }
     // when not in spa mode upload only at server build
     if (isClient && this.options.mode !== 'spa') {


### PR DESCRIPTION
This should fix compatibility with Nuxt >=2.10 while still being compatible with older versions.