### PR TITLE
Invalid root used when computing files to include

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -11,7 +11,7 @@ const filterDisabledIntegration = integrations => Object.keys(integrations)
 
 module.exports = function sentry (moduleOptions) {
   const publicPath = this.options.build.publicPath
-  const buildDirRelative = path.relative(this.options.rootDir, this.options.buildDir)
+  const buildDirRelative = path.relative(process.cwd(), this.options.buildDir)
   const defaults = {
     dsn: process.env.SENTRY_DSN || false,
     disabled: process.env.SENTRY_DISABLED || false,


### PR DESCRIPTION
With the following file structure:

```
- package.json ( nuxt build src/my-app )
- node_modules
- src
|  - my-app
|  | - nuxt.config.js (srcDir: __dirname )
```

The release does not work:
```
error: .nuxt/dist/server: IO error for operation on .nuxt/dist/server: No such file or directory (os error 2)
```

This is due to the fact that the sentry-CLI is run without specifying the CWD and will thus use the package.json's directory as CWD.
In order to compute the right path to the files to release, the process' CWD should be used.

Relevant doc:
https://nuxtjs.org/api/configuration-rootdir/

As you can see, the current implementation only works when the default is being used, and there is no custom path specified with the nuxt command.