### PR TITLE
Set release to auto by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ Normally setting required DSN information would be enough.
   - Default: `process.env.SENTRY_PUBLISH_RELEASE || false`
   - See https://docs.sentry.io/workflow/releases for more information
 
+### attachCommits
+- Type: `Boolean`
+  - Default: `process.env.SENTRY_AUTO_ATTACH_COMMITS || false`
+  - Only has effect when `publishRelease = true`
+
+### repo
+- Type: `String`
+  - Default: `process.env.SENTRY_RELEASE_REPO || false`
+  - Only has effect when `publishRelease = true && attachCommits = true`
+
 ### disableServerRelease
 - Type: `Boolean`
   - Default: `process.env.SENTRY_DISABLE_SERVER_RELEASE || false`

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Normally setting required DSN information would be enough.
 
 ### attachCommits
 - Type: `Boolean`
-  - Default: `process.env.SENTRY_AUTO_ATTACH_COMMITS || false`
+  - Default: `process.env.SENTRY_AUTO_ATTACH_COMMITS === 'true' || true`
   - Only has effect when `publishRelease = true`
 
 ### repo

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Normally setting required DSN information would be enough.
 
 ### attachCommits
 - Type: `Boolean`
-  - Default: `process.env.SENTRY_AUTO_ATTACH_COMMITS === 'true' || true`
+  - Default: `process.env.SENTRY_AUTO_ATTACH_COMMITS !== '0'`
   - Only has effect when `publishRelease = true`
 
 ### repo

--- a/lib/module.js
+++ b/lib/module.js
@@ -21,7 +21,7 @@ module.exports = function sentry (moduleOptions) {
     publishRelease: process.env.SENTRY_PUBLISH_RELEASE || false,
     disableServerRelease: process.env.SENTRY_DISABLE_SERVER_RELEASE || false,
     disableClientRelease: process.env.SENTRY_DISABLE_CLIENT_RELEASE || false,
-    attachCommits: process.env.SENTRY_AUTO_ATTACH_COMMITS === 'true' || true,
+    attachCommits: process.env.SENTRY_AUTO_ATTACH_COMMITS !== '0',
     repo: process.env.SENTRY_RELEASE_REPO || false,
     clientIntegrations: {
       Dedupe: {},

--- a/lib/module.js
+++ b/lib/module.js
@@ -48,7 +48,7 @@ module.exports = function sentry (moduleOptions) {
       urlPrefix: publicPath.startsWith('/') ? `~${publicPath}` : publicPath,
       configFile: '.sentryclirc',
       release: {
-        auto: process.env.SENTRY_AUTO_ATTACH_COMMITS || true,
+        auto: process.env.SENTRY_AUTO_ATTACH_COMMITS || false
       }
     }
   }

--- a/lib/module.js
+++ b/lib/module.js
@@ -21,6 +21,8 @@ module.exports = function sentry (moduleOptions) {
     publishRelease: process.env.SENTRY_PUBLISH_RELEASE || false,
     disableServerRelease: process.env.SENTRY_DISABLE_SERVER_RELEASE || false,
     disableClientRelease: process.env.SENTRY_DISABLE_CLIENT_RELEASE || false,
+    attachCommits: process.env.SENTRY_AUTO_ATTACH_COMMITS || true,
+    repo: process.env.SENTRY_RELEASE_REPO || false,
     clientIntegrations: {
       Dedupe: {},
       ExtraErrorData: {},
@@ -46,10 +48,7 @@ module.exports = function sentry (moduleOptions) {
         '.nuxt/dist/client/img'
       ],
       urlPrefix: publicPath.startsWith('/') ? `~${publicPath}` : publicPath,
-      configFile: '.sentryclirc',
-      release: {
-        auto: process.env.SENTRY_AUTO_ATTACH_COMMITS || true
-      }
+      configFile: '.sentryclirc'
     }
   }
 
@@ -68,6 +67,16 @@ module.exports = function sentry (moduleOptions) {
 
   if (options.config.release && !options.webpackConfig.release) {
     options.webpackConfig.release = options.config.release
+  }
+
+  if (options.attachCommits) {
+    options.webpackConfig.setCommits = {
+      auto: true
+    }
+
+    if (options.repo) {
+      options.webpackConfig.setCommits.repo = options.repo
+    }
   }
 
   const initializationRequired = options.initialize && options.dsn

--- a/lib/module.js
+++ b/lib/module.js
@@ -46,7 +46,10 @@ module.exports = function sentry (moduleOptions) {
         '.nuxt/dist/client/img'
       ],
       urlPrefix: publicPath.startsWith('/') ? `~${publicPath}` : publicPath,
-      configFile: '.sentryclirc'
+      configFile: '.sentryclirc',
+      release: {
+        auto: true,
+      },
     }
   }
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -48,7 +48,7 @@ module.exports = function sentry (moduleOptions) {
       urlPrefix: publicPath.startsWith('/') ? `~${publicPath}` : publicPath,
       configFile: '.sentryclirc',
       release: {
-        auto: process.env.SENTRY_AUTO_ATTACH_COMMITS || false
+        auto: process.env.SENTRY_AUTO_ATTACH_COMMITS || true
       }
     }
   }

--- a/lib/module.js
+++ b/lib/module.js
@@ -48,7 +48,7 @@ module.exports = function sentry (moduleOptions) {
       urlPrefix: publicPath.startsWith('/') ? `~${publicPath}` : publicPath,
       configFile: '.sentryclirc',
       release: {
-        auto: true
+        auto: process.env.SENTRY_AUTO_ATTACH_COMMITS || true,
       }
     }
   }

--- a/lib/module.js
+++ b/lib/module.js
@@ -48,8 +48,8 @@ module.exports = function sentry (moduleOptions) {
       urlPrefix: publicPath.startsWith('/') ? `~${publicPath}` : publicPath,
       configFile: '.sentryclirc',
       release: {
-        auto: true,
-      },
+        auto: true
+      }
     }
   }
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -21,7 +21,7 @@ module.exports = function sentry (moduleOptions) {
     publishRelease: process.env.SENTRY_PUBLISH_RELEASE || false,
     disableServerRelease: process.env.SENTRY_DISABLE_SERVER_RELEASE || false,
     disableClientRelease: process.env.SENTRY_DISABLE_CLIENT_RELEASE || false,
-    attachCommits: process.env.SENTRY_AUTO_ATTACH_COMMITS || true,
+    attachCommits: process.env.SENTRY_AUTO_ATTACH_COMMITS === 'true' || true,
     repo: process.env.SENTRY_RELEASE_REPO || false,
     clientIntegrations: {
       Dedupe: {},


### PR DESCRIPTION
Fixes #121 

It sets the `--auto` flag to `true`. This means that when `publishRelease` is `true`, it will by default auto discover the repo, last commit etc.

If users don't like this behaviour and they can one of two things:

1. Disable attaching commits completely by setting env`SENTRY_AUTO_ATTACH_COMMITS=false` or `attachCommits: false` in config.
2. Set the commit themselves in the `nuxt.config.js`:

```js
export default {
  // ...
  sentry: {
        dsn: 'https://your-dsn@sentry.io/project-id',
        webpackConfig: {
            setCommits: {
                repo: 'organisation/repo-name',
                commit: 'your-commit-hash',
                auto: false,
            },
        },
    },
}
```

Before this should be merged, two PRs at Sentry should be merged first:

- [x] https://github.com/getsentry/sentry-webpack-plugin/pull/156
- [x] https://github.com/getsentry/sentry-cli/pull/618