### PR TITLE
feat: mock sentry in case it is disabled

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -81,17 +81,12 @@ module.exports = function sentry (moduleOptions) {
 
   const initializationRequired = options.initialize && options.dsn
 
-  if (options.disabled) {
-    logger.info('Errors will not be logged because the disable option has been set')
-    return
-  }
-
   if (!options.dsn) {
     logger.info('Errors will not be logged because no DSN has been provided')
   }
 
   // Register the client plugin
-  if (!options.disableClientSide) {
+  if (!options.disabled && !options.disableClientSide) {
     this.addPlugin({
       src: path.resolve(__dirname, 'sentry.client.js'),
       fileName: 'sentry.client.js',
@@ -109,10 +104,17 @@ module.exports = function sentry (moduleOptions) {
           }, {})
       }
     })
+  } else {
+    logger.info('Sentry client side errors will not be logged because the disable option has been set')
+    this.addPlugin({
+      src: path.resolve(__dirname, 'sentry.mocked.js'),
+      fileName: 'sentry.client.js',
+      mode: 'client'
+    })
   }
 
   // Register the server plugin
-  if (!options.disableServerSide) {
+  if (!options.disabled && !options.disableServerSide) {
     // Initialize Sentry
     if (initializationRequired) {
       Sentry.init({
@@ -139,26 +141,35 @@ module.exports = function sentry (moduleOptions) {
         Sentry.captureException(error)
       }))
     })
+  } else {
+    logger.info('Sentry server side errors will not be logged because the disable option has been set')
+    this.addPlugin({
+      src: path.resolve(__dirname, 'sentry.mocked.js'),
+      fileName: 'sentry.server.js',
+      mode: 'server'
+    })
   }
 
   // Enable publishing of sourcemaps
-  this.extendBuild((config, { isClient, isModern, isDev }) => {
-    if (!options.publishRelease || isDev) {
-      return
-    }
-    if (isClient) {
-      config.devtool = 'source-map'
-    }
-    // when not in spa mode upload only at server build
-    if (isClient && this.options.mode !== 'spa') {
-      return
-    }
-    // when in spa mode upload only at modern build if enabled
-    if (isClient && !isModern && this.options.modern) {
-      return
-    }
+  if (!options.disabled) {
+    this.extendBuild((config, { isClient, isModern, isDev }) => {
+      if (!options.publishRelease || isDev) {
+        return
+      }
+      if (isClient) {
+        config.devtool = 'source-map'
+      }
+      // when not in spa mode upload only at server build
+      if (isClient && this.options.mode !== 'spa') {
+        return
+      }
+      // when in spa mode upload only at modern build if enabled
+      if (isClient && !isModern && this.options.modern) {
+        return
+      }
 
-    config.plugins.push(new WebpackPlugin(options.webpackConfig))
-    logger.info('Enabling uploading of release sourcemaps to Sentry')
-  })
+      config.plugins.push(new WebpackPlugin(options.webpackConfig))
+      logger.info('Enabling uploading of release sourcemaps to Sentry')
+    })
+  }
 }

--- a/lib/sentry.mocked.js
+++ b/lib/sentry.mocked.js
@@ -1,0 +1,15 @@
+export default function (ctx, inject) {
+  const handler = {
+    get () {
+      return (...params) => {
+        console.warn(`$sentry.${arguments[1]} called, but sentry plugin is disabled`, params)
+      }
+    }
+  }
+
+  const sentryProxy = new Proxy({}, handler)
+
+  // Inject mocked sentry to the context as $sentry (this is used in case sentry is disabled)
+  inject('sentry', sentryProxy)
+  ctx.$sentry = sentryProxy
+}


### PR DESCRIPTION
as discussed in #84 this would be a way to ensure $sentry is there all the time.

