### PR TITLE
Disable commit releasing by default since it's a breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Normally setting required DSN information would be enough.
 
 ### attachCommits
 - Type: `Boolean`
-  - Default: `process.env.SENTRY_AUTO_ATTACH_COMMITS !== '0'`
+  - Default: `process.env.SENTRY_AUTO_ATTACH_COMMITS || false`
   - Only has effect when `publishRelease = true`
 
 ### repo

--- a/lib/module.js
+++ b/lib/module.js
@@ -21,7 +21,7 @@ module.exports = function sentry (moduleOptions) {
     publishRelease: process.env.SENTRY_PUBLISH_RELEASE || false,
     disableServerRelease: process.env.SENTRY_DISABLE_SERVER_RELEASE || false,
     disableClientRelease: process.env.SENTRY_DISABLE_CLIENT_RELEASE || false,
-    attachCommits: process.env.SENTRY_AUTO_ATTACH_COMMITS !== '0',
+    attachCommits: process.env.SENTRY_AUTO_ATTACH_COMMITS || false,
     repo: process.env.SENTRY_RELEASE_REPO || false,
     clientIntegrations: {
       Dedupe: {},


### PR DESCRIPTION
That change shouldn't have been released in minor version as it
is likely to break workflows since releasing commit often needs extra
configuration/work on the repo and/or sentry side.

For example for me it caused:
[error] Command failed: /var/lib/jenkins/jobs/workspace/node_modules/@sentry/cli/sentry-cli releases set-commits 2.22.107 --auto
error: API request failed
  caused by: sentry reported an error: You do not have permission to perform this action. (http status: 403)