### PR TITLE
fix(types): use @sentry/minimal instead of @sentry/types

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@sentry/integrations": "^5.11.1",
     "@sentry/node": "^5.11.2",
     "@sentry/webpack-plugin": "^1.9.3",
-    "@sentry/types": "^5.11.0",
     "consola": "^2.11.3",
     "deepmerge": "^4.2.2"
   },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,26 +1,26 @@
-import { Client } from '@sentry/types';
+import * as SentryTypes from '@sentry/minimal';
 
 // add type to Vue context
 declare module 'vue/types/vue' {
   interface Vue {
-    readonly $sentry: Client;
+    readonly $sentry: typeof SentryTypes;
   }
 }
 
 // App Context and NuxtAppOptions
 declare module '@nuxt/types' {
   interface Context {
-    readonly $sentry: Client;
+    readonly $sentry: typeof SentryTypes;
   }
 
   interface NuxtAppOptions {
-    readonly $sentry: Client;
+    readonly $sentry: typeof SentryTypes;
   }
 }
 
 // add types for Vuex Store
 declare module 'vuex/types' {
   interface Store<S> {
-    readonly $sentry: Client;
+    readonly $sentry: typeof SentryTypes;
   }
 }


### PR DESCRIPTION
@sentry/types was misleading, and not the right import for the types. essential functions like withScope were not part of the implementation. I checked the sentry code, and found out there is indeed a little difference between client and server, BUT only in terms of configuration. @sentry/minimal is the function set for error logging which all implementations support. regarding error logging they seem all identical. The difference lies in configuration objects like BrowserOptions vs NodeOptions etc...

I also tested with a new sentry.io account how the events look like and how the additional data is appended. Therefore I post it here again, this is the right way to append extras or other data to ONE single event. If you do this.$sentry.setExtra() it will be added to the current global context, and therefore appended to all further events (luckily the global context is bound to the request though and not to the server instance itself). 
```js
this.$sentry.withScope(scope => {
  scope.setExtra('thisIsMyExtra', 'some stuff');
  this.$sentry.captureMessage('hello');
});
```

See also https://docs.sentry.io/enriching-error-data/scopes/?platform=javascript