### PR TITLE
fix: release failure with non-standard directory structure

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -11,7 +11,6 @@ const filterDisabledIntegration = integrations => Object.keys(integrations)
 
 module.exports = function sentry (moduleOptions) {
   const publicPath = this.options.build.publicPath
-  const buildDirRelative = path.relative(this.options.rootDir, this.options.buildDir)
   const defaults = {
     dsn: process.env.SENTRY_DSN || false,
     disabled: process.env.SENTRY_DISABLED || false,
@@ -58,11 +57,13 @@ module.exports = function sentry (moduleOptions) {
   options.serverConfig = deepMerge.all([options.config, options.serverConfig])
   options.clientConfig = deepMerge.all([options.config, options.clientConfig])
 
+  const { buildDir } = this.options
+
   if (!options.disableServerRelease) {
-    options.webpackConfig.include.push(`${buildDirRelative}/dist/server`)
+    options.webpackConfig.include.push(`${buildDir}/dist/server`)
   }
   if (!options.disableClientRelease) {
-    options.webpackConfig.include.push(`${buildDirRelative}/dist/client`)
+    options.webpackConfig.include.push(`${buildDir}/dist/client`)
   }
 
   if (options.config.release && !options.webpackConfig.release) {


### PR DESCRIPTION
With the following project structure:

```
- package.json ( nuxt build src/my-app )
- node_modules
- src
|  - my-app
|  | - nuxt.config.js (srcDir: __dirname )
```

The release did not work:
```
error: .nuxt/dist/server: IO error for operation on .nuxt/dist/server: No such file or directory (os error 2)
```

This was due to the fact that the sentry-CLI is run with working
directory being where package.json is located while the relative
path resolved by the module was relative to the app (my-app) directory.

Fix by passing absolute path to sentry-cli so that it doesn't matter
what's the working directory when it's run.

Relevant doc: https://nuxtjs.org/api/configuration-rootdir/

Fix based on original PR by @matthiusieben - https://github.com/nuxt-community/sentry-module/pull/122

Resolves #132