### PR TITLE
fix: enable source maps on server also

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -156,9 +156,6 @@ module.exports = function sentry (moduleOptions) {
       if (!options.publishRelease || isDev) {
         return
       }
-      if (isClient) {
-        config.devtool = 'source-map'
-      }
       // when not in spa mode upload only at server build
       if (isClient && this.options.mode !== 'spa') {
         return
@@ -167,6 +164,8 @@ module.exports = function sentry (moduleOptions) {
       if (isClient && !isModern && this.options.modern) {
         return
       }
+
+      config.devtool = 'source-map'
 
       config.plugins.push(new WebpackPlugin(options.webpackConfig))
       logger.info('Enabling uploading of release sourcemaps to Sentry')


### PR DESCRIPTION
While nuxt by default enables `cheap-module-source-map` source maps on
server, that doesn't seem to produce any map files in `.nuxt/dist/server/`.
I'm not sure why but in any case, we shouldn't rely on Nuxt as that's
not guaranteed anyway.

Since vue files are also compiled on server, it makes sense to enable
source maps on server also. While I couldn't see evidence of Sentry
using them directly, they do improve stack traces in Node and Sentry
benefits from that indirectly.