### PR TITLE
fix: allow string type to webpackConfig.include

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -58,6 +58,9 @@ module.exports = function sentry (moduleOptions) {
   options.serverConfig = deepMerge.all([options.config, options.serverConfig])
   options.clientConfig = deepMerge.all([options.config, options.clientConfig])
 
+  if (typeof options.webpackConfig.include === 'string') {
+    options.webpackConfig.include = [options.webpackConfig.include]
+  }
   if (!options.disableServerRelease) {
     options.webpackConfig.include.push(`${buildDirRelative}/dist/server`)
   }


### PR DESCRIPTION
Resolves https://github.com/nuxt-community/sentry-module/issues/148