### PR TITLE
fix: don't set urlPrefix for release on server

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -10,7 +10,6 @@ const filterDisabledIntegration = integrations => Object.keys(integrations)
   .filter(key => integrations[key])
 
 module.exports = function sentry (moduleOptions) {
-  const publicPath = this.options.build.publicPath
   const defaults = {
     dsn: process.env.SENTRY_DSN || false,
     disabled: process.env.SENTRY_DISABLED || false,
@@ -46,7 +45,6 @@ module.exports = function sentry (moduleOptions) {
         'node_modules',
         '.nuxt/dist/client/img'
       ],
-      urlPrefix: publicPath.startsWith('/') ? `~${publicPath}` : publicPath,
       configFile: '.sentryclirc'
     }
   }
@@ -153,6 +151,9 @@ module.exports = function sentry (moduleOptions) {
 
   // Enable publishing of sourcemaps
   if (!options.disabled) {
+    const { publicPath } = this.options.build
+    const clientUrlPrefix = publicPath.startsWith('/') ? `~${publicPath}` : publicPath
+
     this.extendBuild((config, { isClient, isModern, isDev }) => {
       if (!options.publishRelease || isDev) {
         return
@@ -167,6 +168,8 @@ module.exports = function sentry (moduleOptions) {
       }
 
       config.devtool = 'source-map'
+
+      options.webpackConfig.urlPrefix = isClient ? clientUrlPrefix : '~/'
 
       config.plugins.push(new WebpackPlugin(options.webpackConfig))
       logger.info('Enabling uploading of release sourcemaps to Sentry')


### PR DESCRIPTION
Only source/map files uploaded for the client need the `_nuxt` prefix.
Server files don't have such prefix concept.