### PR TITLE
fix: router.base not taken into account when releasing source maps

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -1,4 +1,4 @@
-import path from 'path'
+import { resolve, join } from 'path'
 import consola from 'consola'
 import deepMerge from 'deepmerge'
 import * as Sentry from '@sentry/node'
@@ -92,7 +92,7 @@ export default function SentryModule (moduleOptions) {
   // Register the client plugin
   if (!options.disabled && !options.disableClientSide) {
     this.addPlugin({
-      src: path.resolve(__dirname, 'sentry.client.js'),
+      src: resolve(__dirname, 'sentry.client.js'),
       fileName: 'sentry.client.js',
       mode: 'client',
       options: {
@@ -111,7 +111,7 @@ export default function SentryModule (moduleOptions) {
   } else {
     logger.info('Sentry client side errors will not be logged because the disable option has been set')
     this.addPlugin({
-      src: path.resolve(__dirname, 'sentry.mocked.js'),
+      src: resolve(__dirname, 'sentry.mocked.js'),
       fileName: 'sentry.client.js',
       mode: 'client'
     })
@@ -133,7 +133,7 @@ export default function SentryModule (moduleOptions) {
     logger.success('Started logging errors to Sentry')
 
     this.addPlugin({
-      src: path.resolve(__dirname, 'sentry.server.js'),
+      src: resolve(__dirname, 'sentry.server.js'),
       fileName: 'sentry.server.js',
       mode: 'server'
     })
@@ -148,7 +148,7 @@ export default function SentryModule (moduleOptions) {
   } else {
     logger.info('Sentry server side errors will not be logged because the disable option has been set')
     this.addPlugin({
-      src: path.resolve(__dirname, 'sentry.mocked.js'),
+      src: resolve(__dirname, 'sentry.mocked.js'),
       fileName: 'sentry.server.js',
       mode: 'server'
     })
@@ -156,8 +156,10 @@ export default function SentryModule (moduleOptions) {
 
   // Enable publishing of sourcemaps
   if (!options.disabled) {
+    const { base } = this.options.router
     const { publicPath } = this.options.build
-    const clientUrlPrefix = publicPath.startsWith('/') ? `~${publicPath}` : publicPath
+    const clientUrl = join(base, publicPath)
+    const clientUrlPrefix = clientUrl.startsWith('/') ? `~${clientUrl}` : clientUrl
 
     this.extendBuild((config, { isClient, isModern, isDev }) => {
       if (!options.publishRelease || isDev) {


### PR DESCRIPTION
urlPrefix for map files pushed to Sentry needs to be prefixed with
router.base in case user has modified it to be something else than '/'.
Otherwise Sentry can't map paths in client-side errors to uploaded
sources and map files.

Resolves #105