### PR TITLE
fix(types): add types for process.sentry

### DIFF
--- a/types/extend.d.ts
+++ b/types/extend.d.ts
@@ -1,0 +1,26 @@
+import * as SentryTypes from '@sentry/minimal';
+
+// add type to Vue context
+declare module 'vue/types/vue' {
+  interface Vue {
+    readonly $sentry: typeof SentryTypes;
+  }
+}
+
+// App Context and NuxtAppOptions
+declare module '@nuxt/types' {
+  interface Context {
+    readonly $sentry: typeof SentryTypes;
+  }
+
+  interface NuxtAppOptions {
+    readonly $sentry: typeof SentryTypes;
+  }
+}
+
+// add types for Vuex Store
+declare module 'vuex/types' {
+  interface Store<S> {
+    readonly $sentry: typeof SentryTypes;
+  }
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,26 +1,2 @@
-import * as SentryTypes from '@sentry/minimal';
-
-// add type to Vue context
-declare module 'vue/types/vue' {
-  interface Vue {
-    readonly $sentry: typeof SentryTypes;
-  }
-}
-
-// App Context and NuxtAppOptions
-declare module '@nuxt/types' {
-  interface Context {
-    readonly $sentry: typeof SentryTypes;
-  }
-
-  interface NuxtAppOptions {
-    readonly $sentry: typeof SentryTypes;
-  }
-}
-
-// add types for Vuex Store
-declare module 'vuex/types' {
-  interface Store<S> {
-    readonly $sentry: typeof SentryTypes;
-  }
-}
+import './extend';
+import './node';

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -1,0 +1,5 @@
+declare namespace NodeJS {
+    interface Process {
+        sentry: typeof import('@sentry/node');
+    }
+}


### PR DESCRIPTION
Extending a namespace must be done in a definition file that has no
top-level imports so that the file is treated as ambient module
rather than a normal module. For that reason, I couldn't just put new
code in `index.d.ts` but had to create separate file. Stuff from
`index.d.ts` moved to `extend.d.ts` to have a cleaner structure.