### PR TITLE
fix: released client sourcemaps don't have correct prefix (no /_nuxt/)

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -56,30 +56,37 @@ export default function SentryModule (moduleOptions) {
   options.serverConfig = deepMerge.all([options.config, options.serverConfig])
   options.clientConfig = deepMerge.all([options.config, options.clientConfig])
 
-  if (typeof options.webpackConfig.include === 'string') {
-    options.webpackConfig.include = [options.webpackConfig.include]
-  }
+  if (options.publishRelease) {
+    // Set urlPrefix to match resources on the client. That's not technically correct for the server
+    // source maps, but it is what it is for now.
+    const publicPath = join(this.options.router.base, this.options.build.publicPath)
+    options.webpackConfig.urlPrefix = publicPath.startsWith('/') ? `~${publicPath}` : publicPath
 
-  const { buildDir } = this.options
-
-  if (!options.disableServerRelease) {
-    options.webpackConfig.include.push(`${buildDir}/dist/server`)
-  }
-  if (!options.disableClientRelease) {
-    options.webpackConfig.include.push(`${buildDir}/dist/client`)
-  }
-
-  if (options.config.release && !options.webpackConfig.release) {
-    options.webpackConfig.release = options.config.release
-  }
-
-  if (options.attachCommits) {
-    options.webpackConfig.setCommits = {
-      auto: true
+    if (typeof options.webpackConfig.include === 'string') {
+      options.webpackConfig.include = [options.webpackConfig.include]
     }
 
-    if (options.repo) {
-      options.webpackConfig.setCommits.repo = options.repo
+    const { buildDir } = this.options
+
+    if (!options.disableServerRelease) {
+      options.webpackConfig.include.push(`${buildDir}/dist/server`)
+    }
+    if (!options.disableClientRelease) {
+      options.webpackConfig.include.push(`${buildDir}/dist/client`)
+    }
+
+    if (options.config.release && !options.webpackConfig.release) {
+      options.webpackConfig.release = options.config.release
+    }
+
+    if (options.attachCommits) {
+      options.webpackConfig.setCommits = {
+        auto: true
+      }
+
+      if (options.repo) {
+        options.webpackConfig.setCommits.repo = options.repo
+      }
     }
   }
 
@@ -156,15 +163,13 @@ export default function SentryModule (moduleOptions) {
 
   // Enable publishing of sourcemaps
   if (!options.disabled) {
-    const { base } = this.options.router
-    const { publicPath } = this.options.build
-    const clientUrl = join(base, publicPath)
-    const clientUrlPrefix = clientUrl.startsWith('/') ? `~${clientUrl}` : clientUrl
-
     this.extendBuild((config, { isClient, isModern, isDev }) => {
       if (!options.publishRelease || isDev) {
         return
       }
+
+      config.devtool = 'source-map'
+
       // when not in spa mode upload only at server build
       if (isClient && this.options.mode !== 'spa') {
         return
@@ -173,10 +178,6 @@ export default function SentryModule (moduleOptions) {
       if (isClient && !isModern && this.options.modern) {
         return
       }
-
-      config.devtool = 'source-map'
-
-      options.webpackConfig.urlPrefix = isClient ? clientUrlPrefix : '~/'
 
       config.plugins.push(new WebpackPlugin(options.webpackConfig))
       logger.info('Enabling uploading of release sourcemaps to Sentry')


### PR DESCRIPTION
In c71d8488c2b017dcdc2ecdb560b53fe5f4f671f4 I've broken release of
client source maps by not setting `config.devtool = 'source-map'` for
the client build. I've missed the condition that returns early on client
build.

In 8e3e4d1c8289a8abae7337bbca8362da6fc5c1b9 I've also attempted to
configure urlPrefix separately for client and server but I've missed
the fact that client and server source maps were not uploaded
separately but there was only one upload on building server (which
builds second). So the prefix that was actually used was the server
one.

Fix by going to previous logic of setting urlPrefix once (at the expense
of it being incorrect on the server). To fix that properly, we would
need to make two separate releases but that is non-trivial since
releasing can include source maps (client, server) and potentially also
commits. So the fix would have to be fairly elaborate to only release
client in one pass and potentially everything else on server build
(assuming there will be one).