### PR TITLE
Setup WebpackPlugin during webpack:config hook

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -164,24 +164,30 @@ export default function SentryModule (moduleOptions) {
 
   // Enable publishing of sourcemaps
   if (!options.disabled) {
-    this.extendBuild((config, { isClient, isModern, isDev }) => {
-      if (!options.publishRelease || isDev) {
+    this.nuxt.hook('webpack:config', async webpackConfigs => {
+      if (!options.publishRelease || this.options.dev) {
         return
       }
 
-      config.devtool = options.sourceMapStyle
+      webpackConfigs.forEach(config => {
+        config.devtool = options.sourceMapStyle
 
-      // when not in spa mode upload only at server build
-      if (isClient && this.options.mode !== 'spa') {
-        return
-      }
-      // when in spa mode upload only at modern build if enabled
-      if (isClient && !isModern && this.options.modern) {
-        return
-      }
+        const isClient = config.name !== 'server'
+        const isModern = config.name === 'modern'
 
-      config.plugins.push(new WebpackPlugin(options.webpackConfig))
-      logger.info('Enabling uploading of release sourcemaps to Sentry')
+        // when not in spa/universal mode upload only at server build
+        if (isClient && this.options.mode !== 'spa' && this.options.mode !== 'universal') {
+          return
+        }
+        // when in spa/universal mode upload only at modern build if enabled
+        if (isClient && !isModern && this.options.modern) {
+          return
+        }
+
+        config.plugins = config.plugins || []
+        config.plugins.push(new WebpackPlugin(options.webpackConfig))
+        logger.info(`Enabling uploading of release sourcemaps to Sentry for ${config.name}`)
+      })
     })
   }
 }

--- a/lib/module.js
+++ b/lib/module.js
@@ -172,7 +172,7 @@ export default function SentryModule (moduleOptions) {
       webpackConfigs.forEach((config) => {
         config.devtool = options.sourceMapStyle
 
-        const isClient = config.name !== 'server'
+        const isClient = config.name === 'modern' || config.name === 'client'
         const isModern = config.name === 'modern'
 
         // when not in spa/universal mode upload only at server build

--- a/lib/module.js
+++ b/lib/module.js
@@ -164,7 +164,7 @@ export default function SentryModule (moduleOptions) {
 
   // Enable publishing of sourcemaps
   if (!options.disabled) {
-    this.nuxt.hook('webpack:config', async webpackConfigs => {
+    this.nuxt.hook('webpack:config', (webpackConfigs) => {
       if (!options.publishRelease || this.options.dev) {
         return
       }

--- a/lib/module.js
+++ b/lib/module.js
@@ -164,27 +164,23 @@ export default function SentryModule (moduleOptions) {
 
   // Enable publishing of sourcemaps
   if (options.publishRelease && !options.disabled && !this.options.dev) {
+    if (this.options.build.parallel) {
+      throw new Error('@nuxtjs/sentry is not able to publish a release in parallel build mode.')
+    }
+
     this.nuxt.hook('webpack:config', (webpackConfigs) => {
       webpackConfigs.forEach((config) => {
         config.devtool = options.sourceMapStyle
-
-        const isClient = config.name === 'modern' || config.name === 'client'
-        const isModern = config.name === 'modern'
-
-        // when not in spa/universal mode upload only at server build
-        if (isClient && this.options.mode !== 'spa' && this.options.mode !== 'universal') {
-          return
-        }
-        // when in spa/universal mode upload only at modern build if enabled
-        if (isClient && !isModern && this.options.modern) {
-          return
-        }
-
-        config.plugins = config.plugins || []
-        config.plugins.push(new WebpackPlugin(options.webpackConfig))
-
-        logger.info(`Enabling uploading of release sourcemaps to Sentry for "${config.name}" build`)
       })
+
+      // Add WebpackPlugin to latest build config
+
+      const config = webpackConfigs[webpackConfigs.length - 1]
+
+      config.plugins = config.plugins || []
+      config.plugins.push(new WebpackPlugin(options.webpackConfig))
+
+      logger.info('Enabling uploading of release sourcemaps to Sentry')
     })
   }
 }

--- a/lib/module.js
+++ b/lib/module.js
@@ -169,7 +169,7 @@ export default function SentryModule (moduleOptions) {
         config.devtool = options.sourceMapStyle
       })
 
-      // Add WebpackPlugin to latest build config
+      // Add WebpackPlugin to last build config
 
       const config = webpackConfigs[webpackConfigs.length - 1]
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -169,7 +169,7 @@ export default function SentryModule (moduleOptions) {
         return
       }
 
-      webpackConfigs.forEach(config => {
+      webpackConfigs.forEach((config) => {
         config.devtool = options.sourceMapStyle
 
         const isClient = config.name !== 'server'

--- a/lib/module.js
+++ b/lib/module.js
@@ -182,7 +182,8 @@ export default function SentryModule (moduleOptions) {
 
         config.plugins = config.plugins || []
         config.plugins.push(new WebpackPlugin(options.webpackConfig))
-        logger.info(`Enabling uploading of release sourcemaps to Sentry for ${config.name}`)
+
+        logger.info(`Enabling uploading of release sourcemaps to Sentry for "${config.name}" build`)
       })
     })
   }

--- a/lib/module.js
+++ b/lib/module.js
@@ -163,12 +163,8 @@ export default function SentryModule (moduleOptions) {
   }
 
   // Enable publishing of sourcemaps
-  if (!options.disabled) {
+  if (options.publishRelease && !options.disabled && !this.options.dev) {
     this.nuxt.hook('webpack:config', (webpackConfigs) => {
-      if (!options.publishRelease || this.options.dev) {
-        return
-      }
-
       webpackConfigs.forEach((config) => {
         config.devtool = options.sourceMapStyle
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -165,9 +165,9 @@ export default function SentryModule (moduleOptions) {
   // Enable publishing of sourcemaps
   if (options.publishRelease && !options.disabled && !this.options.dev) {
     this.nuxt.hook('webpack:config', (webpackConfigs) => {
-      webpackConfigs.forEach((config) => {
+      for (const config of webpackConfigs) {
         config.devtool = options.sourceMapStyle
-      })
+      }
 
       // Add WebpackPlugin to last build config
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -164,10 +164,6 @@ export default function SentryModule (moduleOptions) {
 
   // Enable publishing of sourcemaps
   if (options.publishRelease && !options.disabled && !this.options.dev) {
-    if (this.options.build.parallel) {
-      throw new Error('@nuxtjs/sentry is not able to publish a release in parallel build mode.')
-    }
-
     this.nuxt.hook('webpack:config', (webpackConfigs) => {
       webpackConfigs.forEach((config) => {
         config.devtool = options.sourceMapStyle


### PR DESCRIPTION
If a custom webpack config is added by another module, that other config would **not** have the `WebpackPlugin` added to its plugins since `extendBuild` is called only when NuxtJS build the initial list of `webpackConfigs`, and not on the actual list of webpack configurations. The `webpack:config` can be used to manipulate the actual list of webpack configuration that will be used, even those added by a custom module. 