### PR TITLE
Leave possibility to fill manually `urlPrefix` field for windows users

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -1,4 +1,4 @@
-import { resolve, join } from 'path'
+import { resolve, posix } from 'path'
 import consola from 'consola'
 import deepMerge from 'deepmerge'
 import * as Sentry from '@sentry/node'
@@ -60,7 +60,7 @@ export default function SentryModule (moduleOptions) {
   if (options.publishRelease) {
     // Set urlPrefix to match resources on the client. That's not technically correct for the server
     // source maps, but it is what it is for now.
-    const publicPath = join(this.options.router.base, this.options.build.publicPath)
+    const publicPath = posix.join(this.options.router.base, this.options.build.publicPath)
     options.webpackConfig.urlPrefix = publicPath.startsWith('/') ? `~${publicPath}` : publicPath
 
     if (typeof options.webpackConfig.include === 'string') {


### PR DESCRIPTION
Because currently upload filename looks like `\_nuxt\/001c573c077135db8d5a.js`
And I want to set `urlPrefix: "~/_nuxt/"` by myself