### PR TITLE
fix: enable console logging of Vue errors in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,10 +311,10 @@ Normally, setting required DSN information would be enough.
       ExtraErrorData: {},
       ReportingObserver: {},
       RewriteFrames: {},
-      Vue: {attachProps: true}
+      Vue: {attachProps: true, logErrors: true}
    }
   ```
-  - See https://docs.sentry.io/platforms/node/pluggable-integrations/ for more information
+  - See https://docs.sentry.io/platforms/javascript/vue/ and  https://docs.sentry.io/platforms/node/pluggable-integrations/ for more information on configuring integrations
 
 ### serverIntegrations
 - Type: `Dictionary`

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Normally, setting required DSN information would be enough.
       ExtraErrorData: {},
       ReportingObserver: {},
       RewriteFrames: {},
-      Vue: {attachProps: true, logErrors: true}
+      Vue: {attachProps: true, logErrors: this.options.dev}
    }
   ```
   - See https://docs.sentry.io/platforms/javascript/vue/ and  https://docs.sentry.io/platforms/node/pluggable-integrations/ for more information on configuring integrations

--- a/lib/module.js
+++ b/lib/module.js
@@ -28,7 +28,7 @@ export default function SentryModule (moduleOptions) {
       ExtraErrorData: {},
       ReportingObserver: {},
       RewriteFrames: {},
-      Vue: { attachProps: true, logErrors: true }
+      Vue: { attachProps: true, logErrors: this.options.dev }
     },
     serverIntegrations: {
       Dedupe: {},

--- a/lib/module.js
+++ b/lib/module.js
@@ -28,7 +28,7 @@ export default function SentryModule (moduleOptions) {
       ExtraErrorData: {},
       ReportingObserver: {},
       RewriteFrames: {},
-      Vue: { attachProps: true }
+      Vue: { attachProps: true, logErrors: true }
     },
     serverIntegrations: {
       Dedupe: {},


### PR DESCRIPTION
Sentry by default swallows all errors caught by Vue error handler. This
options re-posts them so that they show up in the console.

I have always had this enabled in my configuration and I think it makes sense to have it enabled by default.