### PR TITLE
fix: crash on running module outside of git repo when release not set

### DIFF
--- a/lib/core/hooks.js
+++ b/lib/core/hooks.js
@@ -34,13 +34,14 @@ async function getBrowserApiMethods () {
 export async function buildHook (moduleContainer, options, logger) {
   if (!options.config.release) {
     // Determine "config.release" automatically from local repo if not provided.
-    // @ts-ignore
-    const SentryCli = (await import('@sentry/cli')).default
-    const cli = new SentryCli(null, { silent: true })
-    options.config.release = await cli.releases.proposeVersion()
+    try {
       // @ts-ignore
-      .then(version => `${version}`.trim())
-      .catch()
+      const SentryCli = (await import('@sentry/cli')).default
+      const cli = new SentryCli()
+      options.config.release = (await cli.releases.proposeVersion()).trim()
+    } catch {
+      // Ignore
+    }
   }
 
   options.serverConfig = deepMerge.all([options.config, options.serverConfig])


### PR DESCRIPTION
Catch Sentry CLI better to avoid crashing when running outside of git repo.

Resolves #200