### PR TITLE
fix: crash on iterating "delayedCalls"

### DIFF
--- a/lib/plugin.lazy.js
+++ b/lib/plugin.lazy.js
@@ -7,9 +7,9 @@ let SentryMock = {}
 <% } %>
 let sentryReadyResolve
 let loadInitiated = false
+let loadCompleted = false
 
 <% if (options.lazy.injectMock) { %>
-let loadCompleted = false
 const vueErrorHandler = VueLib.config.errorHandler
 
 VueLib.config.errorHandler = (error, vm, info) => {
@@ -42,7 +42,7 @@ export default function SentryPlugin (ctx, inject) {
   ctx.$sentry = SentryMock
   <% } %>
 
-  const loadSentryHook = () => !loadInitiated && loadSentry(ctx, inject)
+  const loadSentryHook = () => attemptLoadSentry(ctx, inject)
 
   <% if (options.lazy.injectLoadHook) { %>
   inject('sentryLoad', loadSentryHook)
@@ -61,7 +61,11 @@ export default function SentryPlugin (ctx, inject) {
   ctx.$sentryReady = sentryReady
 }
 
-async function loadSentry (ctx, inject) {
+async function attemptLoadSentry(ctx, inject) {
+  if (loadInitiated) {
+    return
+  }
+
   loadInitiated = true
 
   if (!window.<%= globals.nuxt %>) {
@@ -69,7 +73,19 @@ async function loadSentry (ctx, inject) {
     // eslint-disable-next-line no-console
     console.warn(`$sentryLoad was called but window.<%= globals.nuxt %> is not available, delaying sentry loading until onNuxtReady callback. Do you really need to use lazy loading for Sentry?`)
     <% } %>
+    <% if (options.lazy.injectLoadHook) { %>
     window.<%= globals.readyCallback %>(() => loadSentry(ctx, inject))
+    <% } else { %>
+    // Wait for onNuxtReady hook to trigger.
+    <% } %>
+    return
+  }
+
+  await loadSentry(ctx, inject)
+}
+
+async function loadSentry (ctx, inject) {
+  if (loadCompleted) {
     return
   }
 
@@ -107,8 +123,8 @@ async function loadSentry (ctx, inject) {
   Sentry.init(config)
   <% } %>
 
-  <% if (options.lazy.injectMock) { %>
   loadCompleted = true
+  <% if (options.lazy.injectMock) { %>
   window.removeEventListener('error', SentryMock.captureException)
 
   delayedCalls.forEach(([methodName, args]) => Sentry[methodName].apply(Sentry, args))

--- a/lib/plugin.lazy.js
+++ b/lib/plugin.lazy.js
@@ -14,7 +14,9 @@ const vueErrorHandler = VueLib.config.errorHandler
 
 VueLib.config.errorHandler = (error, vm, info) => {
   if (!loadCompleted) {
-    vm.$sentry.captureException(error)
+    if (vm) {
+      vm.$sentry.captureException(error)
+    }
 
     if (VueLib.util) {
       VueLib.util.warn(`Error in ${info}: "${error.toString()}"`, vm)


### PR DESCRIPTION
It looks like the code allowed "loadSentry()" to run more than once and
the first run would unset "delayedCalls" causing second run to crash on
trying to iterate it.