### PR TITLE
fix(lazy): improve error reporting for postponed global errors

### DIFF
--- a/lib/plugin.lazy.js
+++ b/lib/plugin.lazy.js
@@ -11,7 +11,13 @@ let loadCompleted = false
 
 <% if (options.lazy.injectMock) { %>
 let delayedGlobalErrors = []
-const delayGlobalError = error => delayedGlobalErrors.push(error)
+let delayedUnhandledRejections = []
+const delayGlobalError = function() {
+  delayedGlobalErrors.push([].slice.call(arguments))
+}
+const delayUnhandledRejection = function(event) {
+  delayedUnhandledRejections.push('reason' in event ? event.reason : 'detail' in event && 'reason' in event.detail ? event.detail.reason : event)
+}
 
 const vueErrorHandler = VueLib.config.errorHandler
 
@@ -42,6 +48,7 @@ export default function SentryPlugin (ctx, inject) {
   })
 
   window.addEventListener('error', delayGlobalError)
+  window.addEventListener('unhandledrejection', delayUnhandledRejection)
 
   inject('sentry', SentryMock)
   ctx.$sentry = SentryMock
@@ -131,22 +138,24 @@ async function loadSentry (ctx, inject) {
   loadCompleted = true
   <% if (options.lazy.injectMock) { %>
   window.removeEventListener('error', delayGlobalError)
+  window.removeEventListener('unhandledrejection', delayUnhandledRejection)
   if (delayedGlobalErrors.length) {
-    console.info('Reposting global error after Sentry has loaded')
-    const  { addExceptionMechanism } = await import(/* <%= magicComments.join(', ') %> */ '@sentry/utils')
-    for (const error of delayedGlobalErrors) {
-      Sentry.withScope(scope => {
-        scope.addEventProcessor(event => {
-          addExceptionMechanism(event, {
-            handled: false,
-            type: 'onerror',
-          });
-          return event;
-        });
-        Sentry.captureException(error);
-      });
+    if (window.onerror) {
+      console.info('Reposting global errors after Sentry has loaded')
+      for (const errorArgs of delayedGlobalErrors) {
+        window.onerror.apply(window, errorArgs)
+      }
     }
     delayedGlobalErrors = []
+  }
+  if (delayedUnhandledRejections.length) {
+    if (window.onunhandledrejection) {
+      console.info('Reposting unhandled promise rejection errors after Sentry has loaded')
+      for (const reason of delayedUnhandledRejections) {
+        window.onunhandledrejection.call(window, reason)
+      }
+    }
+    delayedUnhandledRejections = []
   }
   delayedCalls.forEach(([methodName, args]) => Sentry[methodName].apply(Sentry, args))
   <% } %>

--- a/lib/plugin.lazy.js
+++ b/lib/plugin.lazy.js
@@ -10,6 +10,9 @@ let loadInitiated = false
 let loadCompleted = false
 
 <% if (options.lazy.injectMock) { %>
+let delayedGlobalErrors = []
+const delayGlobalError = error => delayedGlobalErrors.push(error)
+
 const vueErrorHandler = VueLib.config.errorHandler
 
 VueLib.config.errorHandler = (error, vm, info) => {
@@ -38,7 +41,7 @@ export default function SentryPlugin (ctx, inject) {
     SentryMock[key] = (...args) => delayedCalls.push([key, args])
   })
 
-  window.addEventListener('error', SentryMock.captureException)
+  window.addEventListener('error', delayGlobalError)
 
   inject('sentry', SentryMock)
   ctx.$sentry = SentryMock
@@ -127,8 +130,24 @@ async function loadSentry (ctx, inject) {
 
   loadCompleted = true
   <% if (options.lazy.injectMock) { %>
-  window.removeEventListener('error', SentryMock.captureException)
-
+  window.removeEventListener('error', delayGlobalError)
+  if (delayedGlobalErrors.length) {
+    console.info('Reposting global error after Sentry has loaded')
+    const  { addExceptionMechanism } = await import(/* <%= magicComments.join(', ') %> */ '@sentry/utils')
+    for (const error of delayedGlobalErrors) {
+      Sentry.withScope(scope => {
+        scope.addEventProcessor(event => {
+          addExceptionMechanism(event, {
+            handled: false,
+            type: 'onerror',
+          });
+          return event;
+        });
+        Sentry.captureException(error);
+      });
+    }
+    delayedGlobalErrors = []
+  }
   delayedCalls.forEach(([methodName, args]) => Sentry[methodName].apply(Sentry, args))
   <% } %>
 

--- a/lib/plugin.lazy.js
+++ b/lib/plugin.lazy.js
@@ -12,8 +12,9 @@ let loadCompleted = false
 <% if (options.lazy.injectMock) { %>
 let delayedGlobalErrors = []
 let delayedUnhandledRejections = []
-const delayGlobalError = function() {
-  delayedGlobalErrors.push([].slice.call(arguments))
+/** @param {ErrorEvent} event */
+const delayGlobalError = function(event) {
+  delayedGlobalErrors.push([event.message, event.filename, event.lineno, event.colno, event.error])
 }
 const delayUnhandledRejection = function(event) {
   delayedUnhandledRejections.push('reason' in event ? event.reason : 'detail' in event && 'reason' in event.detail ? event.detail.reason : event)


### PR DESCRIPTION
This ensures that the global errors that were delayed will be reported using the same mechanism (`onerror`) as they normally would. Makes it clearer in the Sentry UI what the error is.