### PR TITLE
fix: initialize server-side Sentry when using Nuxt programmatically

### DIFF
--- a/lib/core/hooks.js
+++ b/lib/core/hooks.js
@@ -132,7 +132,7 @@ export async function buildHook (moduleContainer, options, logger) {
       }
     })
 
-    await initSentry(moduleContainer, options)
+    await initializeServerSentry(moduleContainer, options)
   }
 }
 
@@ -201,24 +201,17 @@ export function webpackConfigHook (moduleContainer, webpackConfigs, options, log
 }
 
 /**
- * Handler for the 'listen' hook.
- *
- * @param      {any} moduleContainer The module container
- * @param      {Required<import('../../types/sentry').ModuleConfiguration>} options The module options
- * @return     {Promise<void>}
- */
-export async function listenHook (moduleContainer, options) {
-  await initSentry(moduleContainer, options)
-}
-
-/**
  * Initializes the sentry.
  *
  * @param      {any} moduleContainer The module container
  * @param      {Required<import('../../types/sentry').ModuleConfiguration>} options The module options
  * @return     {Promise<void>}
  */
-export async function initSentry (moduleContainer, options) {
+export async function initializeServerSentry (moduleContainer, options) {
+  if (process.sentry) {
+    return
+  }
+
   // Initializes server-side Sentry directly from the module.
   try {
     const optionsPath = resolve(moduleContainer.options.buildDir, SERVER_CONFIG_FILENAME)

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,7 +1,7 @@
 import consola from 'consola'
 import deepMerge from 'deepmerge'
 import { Handlers as SentryHandlers, captureException, withScope } from '@sentry/node'
-import { buildHook, listenHook, webpackConfigHook } from './core/hooks'
+import { buildHook, initializeServerSentry, webpackConfigHook } from './core/hooks'
 import { boolToText, canInitialize, clientSentryEnabled, envToBool, serverSentryEnabled } from './core/utils'
 
 const logger = consola.withScope('nuxt:sentry')
@@ -91,7 +91,7 @@ export default function SentryModule (moduleOptions) {
   this.nuxt.hook('build:before', () => buildHook(this, options, logger))
 
   if (serverSentryEnabled(options)) {
-    this.nuxt.hook('listen', () => listenHook(this, options))
+    this.nuxt.hook('ready', () => initializeServerSentry(this, options))
   }
 
   // Enable publishing of sourcemaps


### PR DESCRIPTION
Switched from "listen" to "ready" hook so that server-side Sentry is
also initialized when starting Nuxt programmatically from within a server
framework like expressjs.

The side effect of using "ready" hook is that Sentry will also be
initialized on building which seems like an OK thing to do.

Also, in a typical case, "ready" triggers before "listen" which should
actually be better as it would also catch issues with starting server
listener.

Resolves #230