### PR TITLE
feat: add support for performance monitoring/tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,8 @@ Normally, setting required DSN information would be enough.
       vueOptions: {
         tracing: true,
         tracingOptions: {
+          hooks: [ 'mount', 'update' ],
+          timeout: 2000,
           trackComponents: true
         }
       },

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Normally, setting required DSN information would be enough.
   ```
   - See https://docs.sentry.io/platforms/node/pluggable-integrations/ for more information
 
-### enableTracing
+### tracing
 - Type: `Boolean` or `Object`
   - Default: `false`
   - Enables the BrowserTracing integration for client performance monitoring

--- a/README.md
+++ b/README.md
@@ -329,6 +329,27 @@ Normally, setting required DSN information would be enough.
   ```
   - See https://docs.sentry.io/platforms/node/pluggable-integrations/ for more information
 
+### enableTracing
+- Type: `Boolean` or `Object`
+  - Default: `false`
+  - Enables the BrowserTracing integration
+  - A sampling rate can be provided if passing an object (if not provided, the default rate is 1.0):
+  ```js
+    {
+      tracesSampleRate: 0.4
+    }
+  ```
+  - Note that when enabled, the following is added to the `Vue` integration configuration:
+  ```js
+    {
+      tracing: true,
+      tracingOptions: {
+        trackComponents: true
+      }
+    }
+  ```
+  - See https://docs.sentry.io/platforms/javascript/guides/vue/#monitor-performance for more information
+
 ### config
 - Type: `Object`
   - Default: `{
@@ -354,13 +375,13 @@ Normally, setting required DSN information would be enough.
 - Type: `Object`
   - Default: Refer to `module.js` since defaults include various options that also change dynamically based on other options.
   - Options passed to `@sentry/webpack-plugin`. See documentation at https://github.com/getsentry/sentry-webpack-plugin/blob/master/README.md
-  
+
 ### requestHandlerConfig
 - Type: `Object`
   - Default: `{
   }`
   - Options passed to `requestHandler` in `@sentry/node`. See: https://docs.sentry.io/platforms/node/guides/express/
-  
+
 ## Submitting releases to Sentry
 Support for the [sentry-webpack-plugin](https://github.com/getsentry/sentry-webpack-plugin) was introduced [#a6cd8d3](https://github.com/nuxt-community/sentry-module/commit/a6cd8d3b983b4c6659e985736b19dc771fe7c9ea). This can be used to send releases to Sentry. Use the publishRelease  option to enable this feature.
 

--- a/README.md
+++ b/README.md
@@ -332,23 +332,24 @@ Normally, setting required DSN information would be enough.
 ### enableTracing
 - Type: `Boolean` or `Object`
   - Default: `false`
-  - Enables the BrowserTracing integration
-  - A sampling rate can be provided if passing an object (if not provided, the default rate is 1.0):
+  - Enables the BrowserTracing integration for client performance monitoring
+  - Takes the following object configuration format (default values shown):
   ```js
     {
-      tracesSampleRate: 0.4
+      tracesSampleRate: 1.0,
+      vueOptions: {
+        tracing: true,
+        tracingOptions: {
+          trackComponents: true
+        }
+      },
+      browserOptions: {}
     }
   ```
-  - Note that when enabled, the following is added to the `Vue` integration configuration:
-  ```js
-    {
-      tracing: true,
-      tracingOptions: {
-        trackComponents: true
-      }
-    }
-  ```
-  - See https://docs.sentry.io/platforms/javascript/guides/vue/#monitor-performance for more information
+  - Sentry docs strongly recommend reducing the `tracesSampleRate` value; it should be between 0.0 and 1.0 (percentage of requests to capture)
+  - The `vueOptions` are passed to the `Vue` integration, see https://docs.sentry.io/platforms/javascript/guides/vue/#monitor-performance for more information
+  - `browserOptions` are passed to the `BrowserTracing` integration, see https://github.com/getsentry/sentry-javascript/tree/master/packages/tracing for more information
+  - `@sentry/tracing` should be installed manually when using this option (it is currently a dependency of `@sentry/node`)
 
 ### config
 - Type: `Object`

--- a/lib/core/hooks.js
+++ b/lib/core/hooks.js
@@ -84,7 +84,17 @@ export async function buildHook (moduleContainer, options, logger) {
     }
   }
   if (options.enableTracing) {
-    options.clientConfig.tracesSampleRate = options.enableTracing.tracesSampleRate ? options.enableTracing.tracesSampleRate : 1
+    options.enableTracing = deepMerge.all([{
+      tracesSampleRate: 1.0,
+      vueOptions: {
+        tracing: true,
+        tracingOptions: {
+          trackComponents: true
+        }
+      },
+      browserOptions: {}
+    }, options.enableTracing])
+    options.clientConfig.tracesSampleRate = options.enableTracing.tracesSampleRate
   }
 
   // Register the client plugin

--- a/lib/core/hooks.js
+++ b/lib/core/hooks.js
@@ -89,6 +89,8 @@ export async function buildHook (moduleContainer, options, logger) {
       vueOptions: {
         tracing: true,
         tracingOptions: {
+          hooks: [ 'mount', 'update' ],
+          timeout: 2000,
           trackComponents: true
         }
       },

--- a/lib/core/hooks.js
+++ b/lib/core/hooks.js
@@ -83,6 +83,9 @@ export async function buildHook (moduleContainer, options, logger) {
       }
     }
   }
+  if (options.enableTracing) {
+    options.clientConfig.tracesSampleRate = options.enableTracing.tracesSampleRate ? options.enableTracing.tracesSampleRate : 1
+  }
 
   // Register the client plugin
   const pluginOptionClient = clientSentryEnabled(options) ? (options.lazy ? 'lazy' : 'client') : 'mocked'
@@ -99,6 +102,7 @@ export async function buildHook (moduleContainer, options, logger) {
       lazy: options.lazy,
       apiMethods,
       logMockCalls: options.logMockCalls, // for mocked only
+      tracing: options.enableTracing,
       initialize: canInitialize(options),
       integrations: filterDisabledIntegration(options.clientIntegrations)
         .reduce((res, key) => {

--- a/lib/core/hooks.js
+++ b/lib/core/hooks.js
@@ -83,8 +83,8 @@ export async function buildHook (moduleContainer, options, logger) {
       }
     }
   }
-  if (options.enableTracing) {
-    options.enableTracing = deepMerge.all([{
+  if (options.tracing) {
+    options.tracing = deepMerge.all([{
       tracesSampleRate: 1.0,
       vueOptions: {
         tracing: true,
@@ -93,8 +93,8 @@ export async function buildHook (moduleContainer, options, logger) {
         }
       },
       browserOptions: {}
-    }, options.enableTracing])
-    options.clientConfig.tracesSampleRate = options.enableTracing.tracesSampleRate
+    }, options.tracing])
+    options.clientConfig.tracesSampleRate = options.tracing.tracesSampleRate
   }
 
   // Register the client plugin
@@ -112,7 +112,7 @@ export async function buildHook (moduleContainer, options, logger) {
       lazy: options.lazy,
       apiMethods,
       logMockCalls: options.logMockCalls, // for mocked only
-      tracing: options.enableTracing,
+      tracing: options.tracing,
       initialize: canInitialize(options),
       integrations: filterDisabledIntegration(options.clientIntegrations)
         .reduce((res, key) => {

--- a/lib/core/hooks.js
+++ b/lib/core/hooks.js
@@ -89,13 +89,13 @@ export async function buildHook (moduleContainer, options, logger) {
       vueOptions: {
         tracing: true,
         tracingOptions: {
-          hooks: [ 'mount', 'update' ],
+          hooks: ['mount', 'update'],
           timeout: 2000,
           trackComponents: true
         }
       },
       browserOptions: {}
-    }, options.tracing])
+    }, typeof options.tracing === 'boolean' ? {} : options.tracing])
     options.clientConfig.tracesSampleRate = options.tracing.tracesSampleRate
   }
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -23,7 +23,7 @@ export default function SentryModule (moduleOptions) {
     attachCommits: envToBool(process.env.SENTRY_AUTO_ATTACH_COMMITS) || false,
     sourceMapStyle: 'source-map',
     repo: process.env.SENTRY_RELEASE_REPO || '',
-    enableTracing: false,
+    tracing: false,
     clientIntegrations: {
       Dedupe: {},
       ExtraErrorData: {},

--- a/lib/module.js
+++ b/lib/module.js
@@ -23,6 +23,7 @@ export default function SentryModule (moduleOptions) {
     attachCommits: envToBool(process.env.SENTRY_AUTO_ATTACH_COMMITS) || false,
     sourceMapStyle: 'source-map',
     repo: process.env.SENTRY_RELEASE_REPO || '',
+    enableTracing: false,
     clientIntegrations: {
       Dedupe: {},
       ExtraErrorData: {},

--- a/lib/plugin.client.js
+++ b/lib/plugin.client.js
@@ -3,6 +3,9 @@ import * as Sentry from '@sentry/browser'
 <% if (options.initialize) { %>
 import { <%= Object.keys(options.integrations).join(', ') %> } from '@sentry/integrations'
 <% } %>
+<% if (options.tracing) { %>
+import { Integrations as TracingIntegrations } from '@sentry/tracing'
+<% } %>
 
 export default function (ctx, inject) {
   <% if (options.initialize) { %>
@@ -11,6 +14,12 @@ export default function (ctx, inject) {
   config.integrations = [
     <%= Object.entries(options.integrations).map(([name, integration]) => {
       if (name === 'Vue') {
+        if (options.tracing) {
+          integration.tracing = true
+          integration.tracingOptions = {
+            trackComponents: true
+          }
+        }
         return `new ${name}({ Vue: VueLib, ...${serialize(integration)}})`
       }
 
@@ -23,6 +32,9 @@ export default function (ctx, inject) {
       return `new ${name}({${integrationOptions.join(',')}})`
     }).join(',\n    ')%>
   ]
+  <% if (options.tracing) { %>
+    config.integrations.push(<%= `new TracingIntegrations.BrowserTracing()` %>)
+  <% } %>
   /* eslint-enable object-curly-spacing, quote-props, quotes, key-spacing, comma-spacing */
   Sentry.init(config)
   <% } %>

--- a/lib/plugin.client.js
+++ b/lib/plugin.client.js
@@ -15,10 +15,7 @@ export default function (ctx, inject) {
     <%= Object.entries(options.integrations).map(([name, integration]) => {
       if (name === 'Vue') {
         if (options.tracing) {
-          integration.tracing = true
-          integration.tracingOptions = {
-            trackComponents: true
-          }
+          integration = { ...integration, ...options.tracing.vueOptions }
         }
         return `new ${name}({ Vue: VueLib, ...${serialize(integration)}})`
       }
@@ -33,7 +30,7 @@ export default function (ctx, inject) {
     }).join(',\n    ')%>
   ]
   <% if (options.tracing) { %>
-    config.integrations.push(<%= `new TracingIntegrations.BrowserTracing()` %>)
+    config.integrations.push(<%= `new TracingIntegrations.BrowserTracing(${serialize(options.tracing.browserOptions)})` %>)
   <% } %>
   /* eslint-enable object-curly-spacing, quote-props, quotes, key-spacing, comma-spacing */
   Sentry.init(config)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint:fixture": "eslint --ext .vue,.js --no-ignore 'test/fixture/*/.nuxt/sentry.*'",
     "release": "release-it",
     "test:fixture": "jest --runInBand",
-    "test": "yarn lint --fix && yarn test:fixture && yarn lint:fixture",
+    "test": "yarn lint && yarn test:fixture && yarn lint:fixture",
     "coverage": "codecov"
   },
   "babel": {

--- a/types/sentry.d.ts
+++ b/types/sentry.d.ts
@@ -14,6 +14,10 @@ export interface LazyConfiguration {
     webpackPreload?: boolean
 }
 
+export interface TracingConfiguration {
+  tracesSampleRate: number
+}
+
 export interface ModuleConfiguration {
     attachCommits?: boolean
     clientConfig?: SentryOptions
@@ -25,6 +29,7 @@ export interface ModuleConfiguration {
     disableServerRelease?: boolean
     disableServerSide?: boolean
     dsn?: string
+    enableTracing?: boolean | TracingConfiguration
     initialize?: boolean
     lazy?: boolean | LazyConfiguration
     logMockCalls?: boolean

--- a/types/sentry.d.ts
+++ b/types/sentry.d.ts
@@ -1,4 +1,5 @@
 import { Options as WebpackOptions } from 'webpack'
+import { BrowserTracingOptions } from '@sentry/tracing/dist/browser/browsertracing'
 import { Options as SentryOptions } from '@sentry/types'
 import { SentryCliPluginOptions } from '@sentry/webpack-plugin'
 import { Handlers } from '@sentry/node'
@@ -14,15 +15,36 @@ export interface LazyConfiguration {
     webpackPreload?: boolean
 }
 
+/**
+ * Vue specific configuration for Tracing Integration
+ * Not exported, so have to reproduce here
+ * @see https://github.com/getsentry/sentry-javascript/blob/master/packages/integrations/src/vue.ts
+ **/
+interface TracingOptions {
+    /**
+     * Decides whether to track components by hooking into its lifecycle methods.
+     * Can be either set to `boolean` to enable/disable tracking for all of them.
+     * Or to an array of specific component names (case-sensitive).
+     */
+    trackComponents: boolean | string[];
+    /** How long to wait until the tracked root activity is marked as finished and sent of to Sentry */
+    timeout: number;
+    /**
+     * List of hooks to keep track of during component lifecycle.
+     * Available hooks: 'activate' | 'create' | 'destroy' | 'mount' | 'update'
+     * Based on https://vuejs.org/v2/api/#Options-Lifecycle-Hooks
+     */
+    hooks: Operation[];
+}
+declare type Operation = 'activate' | 'create' | 'destroy' | 'mount' | 'update';
+
 export interface TracingConfiguration {
     tracesSampleRate?: number
     vueOptions?: {
         tracing?: boolean
-        tracingOptions?: {
-            trackComponents?: boolean
-        }
-    },
-    browserOptions?: unknown
+        tracingOptions?: TracingOptions
+    }
+    browserOptions?: BrowserTracingOptions
 }
 
 export interface ModuleConfiguration {

--- a/types/sentry.d.ts
+++ b/types/sentry.d.ts
@@ -15,7 +15,7 @@ export interface LazyConfiguration {
     webpackPreload?: boolean
 }
 
-declare type Operation = 'activate' | 'create' | 'destroy' | 'mount' | 'update';
+declare type Operation = 'activate' | 'create' | 'destroy' | 'mount' | 'update'
 /**
  * Vue specific configuration for Tracing Integration
  * Not exported, so have to reproduce here
@@ -27,15 +27,15 @@ interface TracingOptions {
      * Can be either set to `boolean` to enable/disable tracking for all of them.
      * Or to an array of specific component names (case-sensitive).
      */
-    trackComponents: boolean | string[];
+    trackComponents: boolean | string[]
     /** How long to wait until the tracked root activity is marked as finished and sent of to Sentry */
-    timeout: number;
+    timeout: number
     /**
      * List of hooks to keep track of during component lifecycle.
      * Available hooks: 'activate' | 'create' | 'destroy' | 'mount' | 'update'
      * Based on https://vuejs.org/v2/api/#Options-Lifecycle-Hooks
      */
-    hooks: Operation[];
+    hooks: Operation[]
 }
 
 export interface TracingConfiguration {

--- a/types/sentry.d.ts
+++ b/types/sentry.d.ts
@@ -36,7 +36,7 @@ export interface ModuleConfiguration {
     disableServerRelease?: boolean
     disableServerSide?: boolean
     dsn?: string
-    enableTracing?: boolean | TracingConfiguration
+    tracing?: boolean | TracingConfiguration
     initialize?: boolean
     lazy?: boolean | LazyConfiguration
     logMockCalls?: boolean

--- a/types/sentry.d.ts
+++ b/types/sentry.d.ts
@@ -15,7 +15,14 @@ export interface LazyConfiguration {
 }
 
 export interface TracingConfiguration {
-  tracesSampleRate: number
+    tracesSampleRate?: number
+    vueOptions?: {
+        tracing?: boolean
+        tracingOptions?: {
+            trackComponents?: boolean
+        }
+    },
+    browserOptions?: unknown
 }
 
 export interface ModuleConfiguration {

--- a/types/sentry.d.ts
+++ b/types/sentry.d.ts
@@ -15,6 +15,7 @@ export interface LazyConfiguration {
     webpackPreload?: boolean
 }
 
+declare type Operation = 'activate' | 'create' | 'destroy' | 'mount' | 'update';
 /**
  * Vue specific configuration for Tracing Integration
  * Not exported, so have to reproduce here
@@ -36,7 +37,6 @@ interface TracingOptions {
      */
     hooks: Operation[];
 }
-declare type Operation = 'activate' | 'create' | 'destroy' | 'mount' | 'update';
 
 export interface TracingConfiguration {
     tracesSampleRate?: number


### PR DESCRIPTION
Based off the work of @Manfies in #196, but updated to take some of the feedback from the PR into account. 

* Added a top level `enableTracing` option, default `false`
* If enabled, can provide a sample rate value via `tracesSampleRate` property in the option.

This works for my use case, but this is my first contribution to this package so please provide any and all feedback.