### PR TITLE
fix: better handling of functions options in config

### DIFF
--- a/lib/plugin.client.js
+++ b/lib/plugin.client.js
@@ -17,7 +17,13 @@ import { Integrations as TracingIntegrations } from '@sentry/tracing'
 export default function (ctx, inject) {
   <% if (options.initialize) { %>
   /* eslint-disable object-curly-spacing, quote-props, quotes, key-spacing, comma-spacing */
-  const config = <%= serialize(options.config) %>
+  const config = {
+    <%= Object.entries(options.config).map(([key, option]) =>
+      typeof option === 'function'
+        ? `${key}:${serializeFunction(option)}`
+        : `${key}:${serialize(option)}`
+    ).join(',\n    ') %>
+  }
   config.integrations = [
     <%= Object.entries(options.integrations).map(([name, integration]) => {
       if (name === 'Vue') {


### PR DESCRIPTION
Fixes #266 
Check config when the option is a function then using `serializeFunction(option)` instead of using `serialize(option)`