### PR TITLE
fix: crash on lazy loading when using Runtime Config

### DIFF
--- a/lib/plugin.lazy.js
+++ b/lib/plugin.lazy.js
@@ -126,7 +126,7 @@ async function loadSentry (ctx, inject) {
 
   const runtimeConfigKey = <%= serialize(options.runtimeConfigKey) %>
   if (ctx.$config && runtimeConfigKey && ctx.$config[runtimeConfigKey]) {
-    const merge = await import(/* <%= magicComments.join(', ') %> */ 'lodash.merge')
+    const { default: merge } = await import(/* <%= magicComments.join(', ') %> */ 'lodash.merge')
     merge(config, ctx.$config[runtimeConfigKey].config, ctx.$config[runtimeConfigKey].clientConfig)
   }
 

--- a/test/default.test.js
+++ b/test/default.test.js
@@ -21,8 +21,15 @@ describe('Smoke test (default)', () => {
 
   test('builds and runs', async () => {
     const page = await browser.newPage()
+    /** @type {string[]} */
+    const errors = []
+    page.on('pageerror', (error) => {
+      errors.push(error.message)
+    })
     await page.goto(url('/'))
+
     expect(await $$('#server-side', page)).toBe('Works!')
     expect(await $$('#client-side', page)).toBe('Works!')
+    expect(errors).toEqual([])
   })
 })

--- a/test/fixture/lazy/nuxt.config.js
+++ b/test/fixture/lazy/nuxt.config.js
@@ -20,6 +20,13 @@ const config = {
       // Integration from @Sentry/browser package.
       TryCatch: { eventTarget: false }
     }
+  },
+  publicRuntimeConfig: {
+    sentry: {
+      config: {
+        environment: 'production'
+      }
+    }
   }
 }
 

--- a/test/lazy.test.js
+++ b/test/lazy.test.js
@@ -19,10 +19,18 @@ describe('Smoke test (lazy)', () => {
     await nuxt.close()
   })
 
-  test('builds and runs', async () => {
+  test('builds, runs and there are no errors', async () => {
     const page = await browser.newPage()
+
+    /** @type {string[]} */
+    const errors = []
+    page.on('pageerror', (error) => {
+      errors.push(error.message)
+    })
     await page.goto(url('/'))
+
     expect(await $$('#server-side', page)).toBe('Works!')
     expect(await $$('#client-side', page)).toBe('Works and is ready!')
+    expect(errors).toEqual([])
   })
 })

--- a/test/with-lazy-config.test.js
+++ b/test/with-lazy-config.test.js
@@ -26,6 +26,11 @@ describe('Smoke test (lazy config)', () => {
     page.on('console', (msg) => {
       messages.push(msg.text())
     })
+    /** @type {string[]} */
+    const errors = []
+    page.on('pageerror', (error) => {
+      errors.push(error.message)
+    })
     await page.goto(url('/'))
 
     expect(messages).toEqual(expect.arrayContaining(['Caught expected error on $sentry.captureEvent']))
@@ -35,5 +40,6 @@ describe('Smoke test (lazy config)', () => {
     await page.waitForTimeout(1100)
     expect(await $$('#client-side', page)).toBe('Works and is ready!')
     expect(messages).toEqual(expect.arrayContaining(['Sentry is ready']))
+    expect(errors).toEqual([])
   })
 })


### PR DESCRIPTION
Solution for https://github.com/nuxt-community/sentry-module/issues/285

The error occurs because we do a dynamic import of `lodash.merge` which is a CommonJS module.