### PR TITLE
docs: clarification between module and native sentry options

### DIFF
--- a/docs/content/en/guide/setup.md
+++ b/docs/content/en/guide/setup.md
@@ -39,7 +39,12 @@ Then, add `@nuxtjs/sentry` to the `modules` section of `nuxt.config.js`:
   ],
   sentry: {
     dsn: '', // Enter your project's DSN here
-    config: {}, // Additional config
+    // Additional Module Options go here
+    // https://sentry.nuxtjs.org/sentry/options
+    config: {
+    // Add native Sentry config here
+    // https://docs.sentry.io/platforms/javascript/guides/vue/configuration/options/
+    },
   }
 }
 ```

--- a/docs/content/en/guide/setup.md
+++ b/docs/content/en/guide/setup.md
@@ -42,8 +42,8 @@ Then, add `@nuxtjs/sentry` to the `modules` section of `nuxt.config.js`:
     // Additional Module Options go here
     // https://sentry.nuxtjs.org/sentry/options
     config: {
-    // Add native Sentry config here
-    // https://docs.sentry.io/platforms/javascript/guides/vue/configuration/options/
+      // Add native Sentry config here
+      // https://docs.sentry.io/platforms/javascript/guides/vue/configuration/options/
     },
   }
 }


### PR DESCRIPTION
It's confusing that "configuration" is both used for the native sentry options (config object), as well as for the module options. I tried to clarify this a bit in this PR.