### PR TITLE
feat: allow disabling automatic version detection for releases

### DIFF
--- a/lib/core/hooks.js
+++ b/lib/core/hooks.js
@@ -36,7 +36,7 @@ async function getBrowserApiMethods () {
  * @return     {Promise<void>}
  */
 export async function buildHook (moduleContainer, options, logger) {
-  if (!options.config.release) {
+  if (!('release' in options.config)) {
     // Determine "config.release" automatically from local repo if not provided.
     try {
       // @ts-ignore


### PR DESCRIPTION
This small change allows release to be set to undefined without being overridden with automatic release.

In v4 it was possible to set `clientConfig: { release: undefined }` (and same for server) to override automatically generated value. In v5 the merging library has been changed to `lodash.merge` which is ignoring `undefined` values making it no longer possible to override automatic release generation.

We prefer not to include release in the configuration to avoid unnecessary changes to built files (small perf improvement for returning visitors). Instead we rely on `window.SENTRY_RELEASE`/`process.env.SENTRY_RELEASE`. For that to work [release must be undefined](https://github.com/getsentry/sentry-javascript/blob/7f87dd207123d0b2c56e7834f26650de24363d4a/packages/browser/src/sdk.ts#L80-L86).