### PR TITLE
fix: allow overriding all "webpackConfig" options

### DIFF
--- a/docs/content/en/sentry/options.md
+++ b/docs/content/en/sentry/options.md
@@ -155,12 +155,30 @@ Normally, just setting DSN would be enough.
 
 ### publishRelease
 
-- Type: `Boolean`
+- Type: `Boolean` or `[WebpackPluginOptions](https://github.com/getsentry/sentry-webpack-plugin)`
 - Default: `process.env.SENTRY_PUBLISH_RELEASE || false`
-- Enables Sentry releases for better debugging using source maps. (using [@sentry/webpack-plugin](https://github.com/getsentry/sentry-webpack-plugin))
-- This option requires the organization slug, project name and the sentry authentication token to be provided via [environment variables or a properties file](https://docs.sentry.io/product/cli/configuration/#sentry-cli-working-with-projects). So for example when using environment variables you'd set `SENTRY_AUTH_TOKEN`, `SENTRY_ORG` and `SENTRY_PROJECT`.
-- The releases are only published when `publishRelease` is `true` and not running in Nuxt development (`nuxt dev`) mode.
-- See https://docs.sentry.io/workflow/releases for more information
+- Enables Sentry releases for better debugging using source maps. Uses [@sentry/webpack-plugin](https://github.com/getsentry/sentry-webpack-plugin).
+- Publishing releases requires the organization slug, project name and the Sentry authentication token to be provided. Those can be provided either via the `WebpackPluginOptions` object or [environment variables or a properties file](https://docs.sentry.io/product/cli/configuration/#sentry-cli-working-with-projects). So for example, when using the options object, you'd set `authToken`, `org` and `project` options, and when using the environment variables you'd set `SENTRY_AUTH_TOKEN`, `SENTRY_ORG` and `SENTRY_PROJECT`.
+- It's recommended to pass a configuration object to this option rather than using the boolean `true`. When using the boolean, you have to provide required options through other means mentioned above.
+- The releases are only published when this option is enabled and not running in development (`nuxt dev`) mode.
+- See https://docs.sentry.io/workflow/releases for more information. Note that the Sentry CLI options mentioned in the documentation typically have a [@sentry/webpack-plugin](https://github.com/getsentry/sentry-webpack-plugin) equivalent options that can be set through this option.
+
+Example configuration:
+
+```js
+sentry: {
+  // ...
+  publishRelease: {
+    authToken: '<token>',
+    org: 'MyCompany',
+    project: 'my-project',
+    // Attach commits to the release (requires that the build triggered within a git repository).
+    setCommits: {
+      auto: true
+    }
+  }
+}
+```
 
 ### sourceMapStyle
 
@@ -172,15 +190,18 @@ Normally, just setting DSN would be enough.
 
 ### attachCommits
 
+- Deprecated - Set `publishRelease.setCommits.auto = true` instead.
 - Type: `Boolean`
 - Default: `process.env.SENTRY_AUTO_ATTACH_COMMITS || false`
 - Only has effect when `publishRelease = true`
 
 ### repo
 
+- Deprecated - use `publishRelease.setCommmits.repo` instead.
 - Type: `String`
 - Default: `process.env.SENTRY_RELEASE_REPO || ''`
 - Only has effect when `publishRelease = true && attachCommits = true`
+- Alternatively this can be set using `publishRelease.setCommmits.repo` option.
 
 ### disableServerRelease
 
@@ -231,7 +252,7 @@ Normally, just setting DSN would be enough.
 ### tracing
 
 - Type: `Boolean` or `Object`
-  
+
 <alert type="info">
 
   `@sentry/tracing` should be installed manually when using this option (it is currently a dependency of `@sentry/node`)
@@ -262,7 +283,7 @@ Normally, just setting DSN would be enough.
 ### config
 
 - Type: `Object`
-- Default: 
+- Default:
 ```js
   {
     environment: this.options.dev ? 'development' : 'production'
@@ -287,6 +308,7 @@ Normally, just setting DSN would be enough.
 
 ### webpackConfig
 
+- Deprecated - use `publishRelease` instead.
 - Type: `Object`
 - Default: Refer to `module.js` since defaults include various options that also change dynamically based on other options.
 - Only has effect when `publishRelease = true`

--- a/lib/core/hooks.js
+++ b/lib/core/hooks.js
@@ -1,5 +1,5 @@
 import { resolve, posix } from 'path'
-import merge from 'lodash.merge'
+import merge from 'lodash.mergewith'
 import * as Integrations from '@sentry/integrations'
 import * as Sentry from '@sentry/node'
 import WebpackPlugin from '@sentry/webpack-plugin'
@@ -31,7 +31,7 @@ async function getBrowserApiMethods () {
  * Handler for the 'build:before' hook.
  *
  * @param      {any} moduleContainer The module container
- * @param      {Required<import('../../types/sentry').ModuleConfiguration>} options The module options
+ * @param      {import('../../types/sentry').ResolvedModuleConfiguration} options The module options
  * @param      {import('consola').Consola} logger The logger
  * @return     {Promise<void>}
  */
@@ -179,36 +179,39 @@ export async function buildHook (moduleContainer, options, logger) {
  *
  * @param      {any} moduleContainer The module container
  * @param      {any[]} webpackConfigs The webpack configs
- * @param      {Required<import('../../types/sentry').ModuleConfiguration>} options The module options
+ * @param      {Required<import('../../types/sentry').ResolvedModuleConfiguration>} options The module options
  * @param      {import('consola').Consola} logger The logger
  * @return     {void}
  */
 export function webpackConfigHook (moduleContainer, webpackConfigs, options, logger) {
-  if (!options.webpackConfig.urlPrefix) {
+  /** @type {import('@sentry/webpack-plugin').SentryCliPluginOptions} */
+  const publishRelease = merge({}, options.publishRelease)
+
+  if (!publishRelease.urlPrefix) {
     // Set urlPrefix to match resources on the client. That's not technically correct for the server
     // source maps, but it is what it is for now.
     const publicPath = posix.join(moduleContainer.options.router.base, moduleContainer.options.build.publicPath)
-    options.webpackConfig.urlPrefix = publicPath.startsWith('/') ? `~${publicPath}` : publicPath
+    publishRelease.urlPrefix = publicPath.startsWith('/') ? `~${publicPath}` : publicPath
   }
 
-  if (typeof options.webpackConfig.include === 'string') {
-    options.webpackConfig.include = [options.webpackConfig.include]
+  if (typeof publishRelease.include === 'string') {
+    publishRelease.include = [publishRelease.include]
   }
 
   const { buildDir } = moduleContainer.options
 
   if (!options.disableServerRelease) {
-    options.webpackConfig.include.push(`${buildDir}/dist/server`)
+    publishRelease.include.push(`${buildDir}/dist/server`)
   }
   if (!options.disableClientRelease) {
-    options.webpackConfig.include.push(`${buildDir}/dist/client`)
+    publishRelease.include.push(`${buildDir}/dist/client`)
   }
 
-  if (options.config.release && !options.webpackConfig.release) {
-    options.webpackConfig.release = options.config.release
+  if (options.config.release && !publishRelease.release) {
+    publishRelease.release = options.config.release
   }
 
-  if (!options.webpackConfig.release) {
+  if (!publishRelease.release) {
     // We've already tried to determine "release" manually using Sentry CLI so to avoid webpack
     // plugin crashing, we'll just bail here.
     logger.warn('Sentry release will not be published because "config.release" was not set nor it ' +
@@ -217,11 +220,11 @@ export function webpackConfigHook (moduleContainer, webpackConfigs, options, log
   }
 
   if (options.attachCommits) {
-    if (!options.webpackConfig.setCommits) {
-      options.webpackConfig.setCommits = {}
+    if (!publishRelease.setCommits) {
+      publishRelease.setCommits = {}
     }
 
-    const { setCommits } = options.webpackConfig
+    const { setCommits } = publishRelease
 
     if (setCommits.auto === undefined) {
       setCommits.auto = true
@@ -241,14 +244,14 @@ export function webpackConfigHook (moduleContainer, webpackConfigs, options, log
   const config = webpackConfigs[webpackConfigs.length - 1]
 
   config.plugins = config.plugins || []
-  config.plugins.push(new WebpackPlugin(options.webpackConfig))
+  config.plugins.push(new WebpackPlugin(publishRelease))
 }
 
 /**
  * Initializes the sentry.
  *
  * @param      {any} moduleContainer The module container
- * @param      {Required<import('../../types/sentry').ModuleConfiguration>} options The module options
+ * @param      {import('../../types/sentry').ResolvedModuleConfiguration} options The module options
  * @return     {Promise<void>}
  */
 export async function initializeServerSentry (moduleContainer, options) {

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -17,7 +17,7 @@ export const envToBool = env => Boolean(env && env.toLowerCase() !== 'false' && 
 /**
  * Determines if Sentry can be initialized.
  *
- * @param      {Required<import('../../types/sentry').ModuleConfiguration>} options The module options.
+ * @param      {import('../../types/sentry').ResolvedModuleConfiguration} options The module options.
  * @return     {boolean} True if able to initialize, False otherwise.
  */
 export const canInitialize = options => Boolean(options.initialize && options.dsn)
@@ -25,7 +25,7 @@ export const canInitialize = options => Boolean(options.initialize && options.ds
 /**
  * Returns true if browser Sentry is enabled.
  *
- * @param      {Required<import('../../types/sentry').ModuleConfiguration>} options The module options.
+ * @param      {import('../../types/sentry').ResolvedModuleConfiguration} options The module options.
  * @return     {boolean} True if browser Sentry is enabled.
  */
 export const clientSentryEnabled = options => !options.disabled && !options.disableClientSide
@@ -33,7 +33,7 @@ export const clientSentryEnabled = options => !options.disabled && !options.disa
 /**
  * Returns true if node Sentry is enabled.
  *
- * @param      {Required<import('../../types/sentry').ModuleConfiguration>} options The module options.
+ * @param      {import('../../types/sentry').ResolvedModuleConfiguration} options The module options.
  * @return     {boolean} True if node Sentry is enabled.
  */
 export const serverSentryEnabled = options => !options.disabled && !options.disableServerSide

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,10 +1,17 @@
 import consola from 'consola'
-import merge from 'lodash.merge'
+import merge from 'lodash.mergewith'
 import { Handlers as SentryHandlers, captureException, withScope } from '@sentry/node'
 import { buildHook, initializeServerSentry, webpackConfigHook } from './core/hooks'
 import { boolToText, canInitialize, clientSentryEnabled, envToBool, serverSentryEnabled } from './core/utils'
 
 const logger = consola.withScope('nuxt:sentry')
+
+/** @type {import('lodash').MergeWithCustomizer} */
+function mergeWithCustomizer (objValue, srcValue) {
+  if (Array.isArray(objValue)) {
+    return objValue.concat(srcValue)
+  }
+}
 
 /** @type {import('@nuxt/types').Module<import('../types').ModuleConfiguration>} */
 export default function SentryModule (moduleOptions) {
@@ -55,9 +62,16 @@ export default function SentryModule (moduleOptions) {
   }
 
   const topLevelOptions = this.options.sentry || {}
-  const options = /** @type {Required<import('../types/sentry').ModuleConfiguration>} */(
-    merge({}, defaults, topLevelOptions, moduleOptions)
+  const options = /** @type {import('../types/sentry').ResolvedModuleConfiguration} */(
+    merge({}, defaults, topLevelOptions, moduleOptions, mergeWithCustomizer)
   )
+
+  if (options.publishRelease) {
+    const merged = merge(options.webpackConfig, options.publishRelease, mergeWithCustomizer)
+    options.publishRelease = merged
+  }
+
+  options.webpackConfig = {}
 
   if (serverSentryEnabled(options)) {
     // @ts-ignore

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@sentry/node": "^6.11.0",
     "@sentry/webpack-plugin": "^1.17.1",
     "consola": "^2.15.3",
-    "lodash.merge": "^4.6.2"
+    "lodash.mergewith": "^4.6.2"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",
@@ -59,7 +59,7 @@
     "@release-it/conventional-changelog": "^3.2.0",
     "@types/consola": "^2.2.5",
     "@types/jest": "^27.0.1",
-    "@types/lodash.merge": "^4.6.6",
+    "@types/lodash.mergewith": "^4.6.6",
     "@types/node": "^14.17.10",
     "@types/request-promise-native": "^1.0.18",
     "babel-core": "^7.0.0-bridge.0",

--- a/test/fixture/default/nuxt.config.js
+++ b/test/fixture/default/nuxt.config.js
@@ -23,7 +23,8 @@ const config = {
     publishRelease: {
       authToken: 'fakeToken',
       org: 'MyCompany',
-      project: 'TestProject'
+      project: 'TestProject',
+      dryRun: true
     }
   }
 }

--- a/test/fixture/default/nuxt.config.js
+++ b/test/fixture/default/nuxt.config.js
@@ -16,10 +16,14 @@ const config = {
   ],
   sentry: {
     dsn: 'https://fe8b7df6ea7042f69d7a97c66c2934f7@sentry.io.nuxt/1429779',
-    config: {},
     clientIntegrations: {
       // Integration from @Sentry/browser package.
       TryCatch: { eventTarget: false }
+    },
+    publishRelease: {
+      authToken: 'fakeToken',
+      org: 'MyCompany',
+      project: 'TestProject'
     }
   }
 }

--- a/test/fixture/default/nuxt.config.js
+++ b/test/fixture/default/nuxt.config.js
@@ -4,7 +4,6 @@ import SentryModule from '../../..'
 const config = {
   rootDir: __dirname,
   telemetry: false,
-  dev: true,
   build: {
     terser: false
   },

--- a/types/sentry.d.ts
+++ b/types/sentry.d.ts
@@ -49,6 +49,7 @@ export interface TracingConfiguration {
 }
 
 export interface ModuleConfiguration {
+    /** @deprecated Set `publishRelease.setCommits.auto = true` instead. */
     attachCommits?: boolean
     clientConfig?: BrowserOptions
     clientIntegrations?: IntegrationsConfiguration
@@ -63,12 +64,19 @@ export interface ModuleConfiguration {
     initialize?: boolean
     lazy?: boolean | LazyConfiguration
     logMockCalls?: boolean
-    publishRelease?: boolean
+    /** See available options at https://github.com/getsentry/sentry-webpack-plugin */
+    publishRelease?: boolean | Partial<SentryCliPluginOptions>
+    /** @deprecated Set `publishRelease.setCommits.repo` instead. */
     repo?: string
     runtimeConfigKey?: string
     serverConfig?: SentryOptions
     serverIntegrations?: IntegrationsConfiguration
     sourceMapStyle?: WebpackOptions.Devtool
-    webpackConfig?: SentryCliPluginOptions
+    /** @deprecated Use `publishRelease` instead. */
+    webpackConfig?: Partial<SentryCliPluginOptions>
     requestHandlerConfig?: Handlers.RequestHandlerOptions
+}
+
+interface ResolvedModuleConfiguration extends Omit<Required<ModuleConfiguration>, 'publishRelease'> {
+    publishRelease?: Partial<SentryCliPluginOptions>
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2082,10 +2082,10 @@
   resolved "https://registry.yarnpkg.com/@types/less/-/less-3.0.2.tgz#2761d477678c8374cb9897666871662eb1d1115e"
   integrity sha512-62vfe65cMSzYaWmpmhqCMMNl0khen89w57mByPi1OseGfcV/LV03fO8YVrNj7rFQsRWNJo650WWyh6m7p8vZmA==
 
-"@types/lodash.merge@^4.6.6":
+"@types/lodash.mergewith@^4.6.6":
   version "4.6.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.merge/-/lodash.merge-4.6.6.tgz#b84b403c1d31bc42d51772d1cd5557fa008cd3d6"
-  integrity sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==
+  resolved "https://registry.yarnpkg.com/@types/lodash.mergewith/-/lodash.mergewith-4.6.6.tgz#c4698f5b214a433ff35cb2c75ee6ec7f99d79f10"
+  integrity sha512-RY/8IaVENjG19rxTZu9Nukqh0W2UrYgmBj5sdns4hWRZaV8PqR7wIKHFKzvOTjo4zVRV7sVI+yFhAJql12Kfqg==
   dependencies:
     "@types/lodash" "*"
 
@@ -7874,6 +7874,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.mergewith@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
+  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
 lodash.template@^4.5.0:
   version "4.5.0"


### PR DESCRIPTION
Apart from allowing all webpackConfig options to be overridden, also
deprecate "webpackConfig" and other publish-release-specific options
and accept a configuration object for the "publishRelease" option.