### PR TITLE
fix: shutdown Sentry instance after generate

### DIFF
--- a/lib/core/hooks.js
+++ b/lib/core/hooks.js
@@ -286,3 +286,11 @@ export async function initializeServerSentry (moduleContainer, options) {
 
   process.sentry = Sentry
 }
+
+export async function shutdownServerSentry () {
+  if (process.sentry) {
+    await process.sentry.close()
+    // @ts-ignore
+    process.sentry = undefined
+  }
+}

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,7 +1,7 @@
 import consola from 'consola'
 import merge from 'lodash.mergewith'
 import { Handlers as SentryHandlers, captureException, withScope } from '@sentry/node'
-import { buildHook, initializeServerSentry, webpackConfigHook } from './core/hooks'
+import { buildHook, initializeServerSentry, shutdownServerSentry, webpackConfigHook } from './core/hooks'
 import { boolToText, canInitialize, clientSentryEnabled, envToBool, serverSentryEnabled } from './core/utils'
 
 const logger = consola.withScope('nuxt:sentry')
@@ -109,6 +109,7 @@ export default function SentryModule (moduleOptions) {
 
   if (serverSentryEnabled(options)) {
     this.nuxt.hook('ready', () => initializeServerSentry(this, options))
+    this.nuxt.hook('generate:done', () => shutdownServerSentry())
   }
 
   // Enable publishing of sourcemaps

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "main": "lib/module.js",
   "scripts": {
     "dev:fixture": "nuxt -c ./test/fixture/default/nuxt.config.js",
+    "dev:generate": "nuxt generate -c ./test/fixture/default/nuxt.config.js",
     "lint": "eslint --ext .vue,.js,.ts lib test types",
     "lint:fixture": "eslint --ext .vue,.js --no-ignore 'test/fixture/*/.nuxt/sentry.*'",
     "release": "release-it",


### PR DESCRIPTION
To avoid Sentry blocking the message loop and triggering a warning
that it's blocking the exit, explicitly shutdown Sentry after generating.

Fixes #352