### PR TITLE
fix(docs): typo in the lazy-loading section

### DIFF
--- a/docs/content/en/sentry/lazy-loading.md
+++ b/docs/content/en/sentry/lazy-loading.md
@@ -53,9 +53,9 @@ Example usage:
     // that triggered the load will also be captured
     this.errorListener = () => {
       this.$sentryLoad()
-      window.removeEventListener('error', errorListener)
+      window.removeEventListener('error', this.errorListener)
     }
-    window.addEventListener('error', errorListener)
+    window.addEventListener('error', this.errorListener)
   },
   destroyed() {
     window.removeEventListener('error', this.errorListener)


### PR DESCRIPTION
I suppose `errorListener` should be called on `this` in the following example:

```js
  mounted() {
    // This will only load sentry once an error was thrown
    // To prevent a chicken & egg issue, make sure to also
    // set injectMock: true if you use this so the error
    // that triggered the load will also be captured
    this.errorListener = () => {
      this.$sentryLoad()
      window.removeEventListener('error', errorListener)
    }
    window.addEventListener('error', errorListener)
  },
  destroyed() {
    window.removeEventListener('error', this.errorListener)
  }
```