### PR TITLE
fix: don't pass empty object to integrations constructor

### DIFF
--- a/lib/core/hooks.js
+++ b/lib/core/hooks.js
@@ -279,8 +279,11 @@ export async function initializeServerSentry (moduleContainer, options) {
       dsn: options.dsn,
       ...options.serverConfig,
       integrations: filterDisabledIntegration(options.serverIntegrations)
-        // @ts-ignore
-        .map(name => new Integrations[name](options.serverIntegrations[name]))
+        .map((name) => {
+          const opt = options.serverIntegrations[name]
+          // @ts-ignore
+          return Object.keys(opt).length ? new Integrations[name](opt) : new Integrations[name]()
+        })
     })
   }
 


### PR DESCRIPTION
Some context in https://github.com/getsentry/sentry-javascript/issues/4186
which shows that passing empty object to some integrations (ExtraErrorData
for example) will make it not assume default values for some options.