### PR TITLE
fix: don't pass empty object to integrations constructor

### DIFF
--- a/lib/plugin.client.js
+++ b/lib/plugin.client.js
@@ -46,7 +46,7 @@ export default function (ctx, inject) {
           : `${key}:${serialize(option)}`
       )
 
-      return `new ${name}({${integrationOptions.join(',')}})`
+      return `new ${name}(${integrationOptions.length ? '{' + integrationOptions.join(',') + '}' : ''})`
     }).join(',\n    ')%>
   ]
   <% if (options.tracing) { %>

--- a/lib/plugin.lazy.js
+++ b/lib/plugin.lazy.js
@@ -142,7 +142,7 @@ async function loadSentry (ctx, inject) {
           : `${key}:${serialize(option)}`
       )
 
-      return `new ${name}({${integrationOptions.join(',')}})`
+      return `new ${name}(${integrationOptions.length ? '{' + integrationOptions.join(',') + '}' : ''})`
     }).join(',\n    ')%>
   ]
   /* eslint-enable object-curly-spacing, quote-props, quotes, key-spacing, comma-spacing */


### PR DESCRIPTION
This workarounds an issue in Sentry (https://github.com/getsentry/sentry-javascript/issues/4186) where ExtraErrorData integration doesn't limit to the default depth of 3 when empty options are passed.

I'm also fixing it in Sentry SDK at https://github.com/getsentry/sentry-javascript/pull/4487

This was previously fixed for the server-side (#376) but I've missed doing the same on client-side.
