### PR TITLE
refactor(options)!: remove deprecated "attachCommits" and "repo"

### DIFF
--- a/docs/content/en/sentry/options.md
+++ b/docs/content/en/sentry/options.md
@@ -194,21 +194,6 @@ sentry: {
 - The type of source maps generated when publishing release to Sentry. See https://webpack.js.org/configuration/devtool for a list of available options
 - **Note**: Consider using `hidden-source-map` instead. For most people, that should be a better option but due to it being a breaking change, it won't be set as the default until next major release
 
-### attachCommits
-
-- Deprecated - Set `publishRelease.setCommits.auto = true` instead.
-- Type: `Boolean`
-- Default: `process.env.SENTRY_AUTO_ATTACH_COMMITS || false`
-- Only has effect when `publishRelease = true`
-
-### repo
-
-- Deprecated - use `publishRelease.setCommmits.repo` instead.
-- Type: `String`
-- Default: `process.env.SENTRY_RELEASE_REPO || ''`
-- Only has effect when `publishRelease = true && attachCommits = true`
-- Alternatively this can be set using `publishRelease.setCommmits.repo` option.
-
 ### disableServerRelease
 
 - Type: `Boolean`

--- a/lib/core/hooks.js
+++ b/lib/core/hooks.js
@@ -2,7 +2,7 @@ import { resolve, posix } from 'path'
 import merge from 'lodash.mergewith'
 import * as Integrations from '@sentry/integrations'
 import * as Sentry from '@sentry/node'
-import { canInitialize, clientSentryEnabled, serverSentryEnabled } from './utils'
+import { canInitialize, clientSentryEnabled, envToBool, serverSentryEnabled } from './utils'
 
 const SERVER_CONFIG_FILENAME = 'sentry.server.config.js'
 const SENTRY_PLUGGABLE_INTEGRATIONS = ['CaptureConsole', 'Debug', 'Dedupe', 'ExtraErrorData', 'ReportingObserver', 'RewriteFrames', 'Vue']
@@ -227,10 +227,10 @@ export async function webpackConfigHook (moduleContainer, webpackConfigs, option
     return
   }
 
-  if (options.attachCommits) {
-    if (!publishRelease.setCommits) {
-      publishRelease.setCommits = {}
-    }
+  const attachCommits = envToBool(process.env.SENTRY_AUTO_ATTACH_COMMITS)
+
+  if (attachCommits) {
+    publishRelease.setCommits = publishRelease.setCommits || {}
 
     const { setCommits } = publishRelease
 
@@ -238,8 +238,10 @@ export async function webpackConfigHook (moduleContainer, webpackConfigs, option
       setCommits.auto = true
     }
 
-    if (options.repo && setCommits.repo === undefined) {
-      setCommits.repo = options.repo
+    const repo = process.env.SENTRY_RELEASE_REPO || ''
+
+    if (repo && setCommits.repo === undefined) {
+      setCommits.repo = repo
     }
   }
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -28,9 +28,7 @@ export default function SentryModule (moduleOptions) {
     disableServerRelease: envToBool(process.env.SENTRY_DISABLE_SERVER_RELEASE) || false,
     disableClientRelease: envToBool(process.env.SENTRY_DISABLE_CLIENT_RELEASE) || false,
     logMockCalls: true,
-    attachCommits: envToBool(process.env.SENTRY_AUTO_ATTACH_COMMITS) || false,
     sourceMapStyle: 'source-map',
-    repo: process.env.SENTRY_RELEASE_REPO || '',
     tracing: false,
     clientIntegrations: {
       Dedupe: {},

--- a/types/sentry.d.ts
+++ b/types/sentry.d.ts
@@ -49,8 +49,6 @@ export interface TracingConfiguration {
 }
 
 export interface ModuleConfiguration {
-    /** @deprecated Set `publishRelease.setCommits.auto = true` instead. */
-    attachCommits?: boolean
     clientConfig?: BrowserOptions
     clientIntegrations?: IntegrationsConfiguration
     config?: SentryOptions
@@ -66,8 +64,6 @@ export interface ModuleConfiguration {
     logMockCalls?: boolean
     /** See available options at https://github.com/getsentry/sentry-webpack-plugin */
     publishRelease?: boolean | Partial<SentryCliPluginOptions>
-    /** @deprecated Set `publishRelease.setCommits.repo` instead. */
-    repo?: string
     runtimeConfigKey?: string
     serverConfig?: SentryOptions
     serverIntegrations?: IntegrationsConfiguration


### PR DESCRIPTION
BREAKING CHANGE: The removed `attachCommits` and `repo` options can be
set through the `publishRelease` object.