### PR TITLE
refactor(options)!: remove deprecated "webpackConfig"

### DIFF
--- a/docs/content/en/sentry/options.md
+++ b/docs/content/en/sentry/options.md
@@ -186,6 +186,22 @@ sentry: {
 }
 ```
 
+Note the the module sets the following defaults when publishing is enabled:
+
+```js
+{
+  include: [], // automatically set at publishing time to relevant paths for the bundles that were built
+  ignore: [
+    'node_modules',
+    '.nuxt/dist/client/img'
+  ],
+  configFile: '.sentryclirc',
+  release: '',  // defaults to the value of "config.release" which can either be set manually or is determined automatically through `@sentry/cli`
+}
+```
+
+- Providing custom values for `include` or `ignore` will result in provided values getting appended to default values.
+
 ### sourceMapStyle
 
 - Type: `String`
@@ -308,14 +324,6 @@ sentry: {
 - Type: `Object`
 - Default: `{}`
 - Specified keys will override common Sentry options for client sentry plugin
-
-### webpackConfig
-
-- Deprecated - use `publishRelease` instead.
-- Type: `Object`
-- Default: Refer to `module.js` since defaults include various options that also change dynamically based on other options.
-- Only has effect when `publishRelease = true`
-- Options passed to `@sentry/webpack-plugin`. See documentation at https://github.com/getsentry/sentry-webpack-plugin/blob/master/README.md
 
 ### requestHandlerConfig
 

--- a/lib/core/hooks.js
+++ b/lib/core/hooks.js
@@ -202,8 +202,9 @@ export async function webpackConfigHook (moduleContainer, webpackConfigs, option
     publishRelease.urlPrefix = publicPath.startsWith('/') ? `~${publicPath}` : publicPath
   }
 
-  if (typeof publishRelease.include === 'string') {
-    publishRelease.include = [publishRelease.include]
+  if (!Array.isArray(publishRelease.include)) {
+    const { include } = publishRelease
+    publishRelease.include = [...(include ? [include] : [])]
   }
 
   const { buildDir } = moduleContainer.options

--- a/lib/module.js
+++ b/lib/module.js
@@ -48,15 +48,17 @@ export default function SentryModule (moduleOptions) {
     },
     serverConfig: {},
     clientConfig: {},
-    webpackConfig: {
-      include: [],
-      ignore: [
-        'node_modules',
-        '.nuxt/dist/client/img'
-      ],
-      configFile: '.sentryclirc'
-    },
     requestHandlerConfig: {}
+  }
+
+  /** @type {import('@sentry/webpack-plugin').SentryCliPluginOptions} */
+  const defaultsPublishRelease = {
+    include: [],
+    ignore: [
+      'node_modules',
+      '.nuxt/dist/client/img'
+    ],
+    configFile: '.sentryclirc'
   }
 
   const topLevelOptions = this.options.sentry || {}
@@ -65,11 +67,9 @@ export default function SentryModule (moduleOptions) {
   )
 
   if (options.publishRelease) {
-    const merged = merge(options.webpackConfig, options.publishRelease, mergeWithCustomizer)
+    const merged = merge(defaultsPublishRelease, options.publishRelease, mergeWithCustomizer)
     options.publishRelease = merged
   }
-
-  options.webpackConfig = {}
 
   if (serverSentryEnabled(options)) {
     // @ts-ignore

--- a/types/sentry.d.ts
+++ b/types/sentry.d.ts
@@ -68,8 +68,6 @@ export interface ModuleConfiguration {
     serverConfig?: SentryOptions
     serverIntegrations?: IntegrationsConfiguration
     sourceMapStyle?: WebpackOptions.Devtool
-    /** @deprecated Use `publishRelease` instead. */
-    webpackConfig?: Partial<SentryCliPluginOptions>
     requestHandlerConfig?: Handlers.RequestHandlerOptions
 }
 


### PR DESCRIPTION
BREAKING CHANGE: Configure through the publishRelease object instead.