### PR TITLE
fix!: describe a breaking change

### DIFF
--- a/lib/core/hooks.js
+++ b/lib/core/hooks.js
@@ -9,7 +9,7 @@ const RESOLVED_RELEASE_FILENAME = 'sentry.release.config.js'
 /**
  * Resolves the options and creates the plugins and the templates at build time.
  *
- * @param      {any} moduleContainer The module container
+ * @param      {ThisParameterType<import('@nuxt/types').Module>} moduleContainer
  * @param      {import('../../types/sentry').ResolvedModuleConfiguration} moduleOptions The module options
  * @param      {import('consola').Consola} logger The logger
  * @return     {Promise<void>}
@@ -47,7 +47,7 @@ export async function buildHook (moduleContainer, moduleOptions, logger) {
 /**
  * Handler for the 'webpack:config' hook
  *
- * @param      {any} moduleContainer The module container
+ * @param      {ThisParameterType<import('@nuxt/types').Module>} moduleContainer
  * @param      {any[]} webpackConfigs The webpack configs
  * @param      {Required<import('../../types/sentry').ResolvedModuleConfiguration>} options The module options
  * @param      {import('consola').Consola} logger The logger
@@ -65,12 +65,14 @@ export async function webpackConfigHook (moduleContainer, webpackConfigs, option
 
   /** @type {import('@sentry/webpack-plugin').SentryCliPluginOptions} */
   const publishRelease = merge({}, options.publishRelease)
+  const nuxtOptions = moduleContainer.options
 
   if (!publishRelease.urlPrefix) {
-    // Set urlPrefix to match resources on the client. That's not technically correct for the server
-    // source maps, but it is what it is for now.
-    const publicPath = posix.join(moduleContainer.options.router.base, moduleContainer.options.build.publicPath)
-    publishRelease.urlPrefix = publicPath.startsWith('/') ? `~${publicPath}` : publicPath
+    // Set urlPrefix to match resources on the client. That's not technically correct for the server source maps, but it is what it is for now.
+    if (typeof (nuxtOptions.router.base) === 'string' && typeof (nuxtOptions.build.publicPath) === 'string') {
+      const publicPath = posix.join(nuxtOptions.router.base, nuxtOptions.build.publicPath)
+      publishRelease.urlPrefix = publicPath.startsWith('/') ? `~${publicPath}` : publicPath
+    }
   }
 
   if (!Array.isArray(publishRelease.include)) {
@@ -78,7 +80,7 @@ export async function webpackConfigHook (moduleContainer, webpackConfigs, option
     publishRelease.include = [...(include ? [include] : [])]
   }
 
-  const { buildDir } = moduleContainer.options
+  const { buildDir } = nuxtOptions
 
   if (!options.disableServerRelease) {
     publishRelease.include.push(`${buildDir}/dist/server`)
@@ -130,7 +132,7 @@ export async function webpackConfigHook (moduleContainer, webpackConfigs, option
 /**
  * Initializes the sentry.
  *
- * @param      {any} moduleContainer
+ * @param      {ThisParameterType<import('@nuxt/types').Module>} moduleContainer
  * @param      {import('../../types/sentry').ResolvedModuleConfiguration} moduleOptions
  * @param      {import('consola').Consola} logger
  * @return     {Promise<void>}

--- a/lib/core/hooks.js
+++ b/lib/core/hooks.js
@@ -7,7 +7,7 @@ import { resolveRelease, resolveClientOptions, resolveServerOptions } from './op
 const RESOLVED_RELEASE_FILENAME = 'sentry.release.config.js'
 
 /**
- * Handler for the 'build:before' hook.
+ * Resolves the options and creates the plugins and the templates at build time.
  *
  * @param      {any} moduleContainer The module container
  * @param      {import('../../types/sentry').ResolvedModuleConfiguration} moduleOptions The module options

--- a/lib/core/options.js
+++ b/lib/core/options.js
@@ -109,7 +109,7 @@ function resolveTracingOptions (options) {
 }
 
 /**
- * @param {any} moduleContainer The module container
+ * @param {ThisParameterType<import('@nuxt/types').Module>} moduleContainer
  * @param {import('../../types/sentry').ResolvedModuleConfiguration} moduleOptions
  * @param {import('consola').Consola} logger
  * @return {Promise<any>}
@@ -155,7 +155,7 @@ export async function resolveClientOptions (moduleContainer, moduleOptions, logg
 }
 
 /**
- * @param {any} moduleContainer The module container
+ * @param {ThisParameterType<import('@nuxt/types').Module>} moduleContainer
  * @param {import('../../types/sentry').ResolvedModuleConfiguration} moduleOptions
  * @param {import('consola').Consola} logger
  * @return {Promise<any>}
@@ -184,7 +184,7 @@ export async function resolveServerOptions (moduleContainer, moduleOptions, logg
 
   const { publicRuntimeConfig } = moduleContainer.options
   const { runtimeConfigKey } = options
-  if (publicRuntimeConfig && runtimeConfigKey && publicRuntimeConfig[runtimeConfigKey]) {
+  if (typeof (publicRuntimeConfig) !== 'function' && runtimeConfigKey && runtimeConfigKey in publicRuntimeConfig) {
     merge(options.config, publicRuntimeConfig[runtimeConfigKey].config, publicRuntimeConfig[runtimeConfigKey].serverConfig)
   }
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -112,8 +112,9 @@ export default function SentryModule (moduleOptions) {
   // - nuxt generate
   // but it doesn't really provide great way to differentiate those or enough hooks to
   // pick from. This should ensure that server Sentry will only be initialized **after**
-  // the build was done (after release version has been determined and the options template created).
-  const initHook = this.options._build ? 'build:done' : 'ready'
+  // the release version has been determined and the options template created but before
+  // the build is started (if building).
+  const initHook = this.options._build ? 'build:compile' : 'ready'
   if (serverSentryEnabled(options)) {
     this.nuxt.hook(initHook, () => initializeServerSentry(this, options, logger))
     this.nuxt.hook('generate:done', () => shutdownServerSentry())

--- a/lib/module.js
+++ b/lib/module.js
@@ -112,9 +112,9 @@ export default function SentryModule (moduleOptions) {
   // - nuxt generate
   // but it doesn't really provide great way to differentiate those or enough hooks to
   // pick from. This should ensure that server Sentry will only be initialized **after**
-  // the build was done (after release version has been determined).
-  const initHook = this.options._start ? 'ready' : 'build:done'
-  if (initHook && serverSentryEnabled(options)) {
+  // the build was done (after release version has been determined and the options template created).
+  const initHook = this.options._build ? 'build:done' : 'ready'
+  if (serverSentryEnabled(options)) {
     this.nuxt.hook(initHook, () => initializeServerSentry(this, options, logger))
     this.nuxt.hook('generate:done', () => shutdownServerSentry())
   }


### PR DESCRIPTION
BREAKING CHANGE: The server-side process.sentry will be created slightly later than before WHEN running the "build" action. It will be created before the pages are built (on `build:compile` hook) while before it was available a bit earlier on `ready` hook (with an issue that it was not always able to pass the project version to Sentry).