### PR TITLE
chore(ci): disable node 12 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       CI: true
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
     name: Use Node.js ${{ matrix.node-version }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Time to move on.

One issue is with `release-it` that doesn't support node 12 anymore but Nuxt also doesn't really as it expects that latest LTS version is used (16 at this time).