### PR TITLE
fix(tracing): set `tracesSampleRate` when `tracing` enabled

### DIFF
--- a/lib/core/options.js
+++ b/lib/core/options.js
@@ -86,11 +86,16 @@ function resolveLazyOptions (options, apiMethods, logger) {
 }
 
 /**
- * @param {import('../../types/sentry').ResolvedModuleConfiguration} options
+ * @param {import('../../types/sentry').ModuleConfiguration['tracing']} tracing
+ * @param {NonNullable<import('../../types/sentry').ModuleConfiguration['config']>} config
  */
-function resolveTracingOptions (options) {
-  if (options.tracing) {
-    options.tracing = merge({
+function resolveTracingOptions (tracing, config) {
+  if (!tracing) {
+    return
+  }
+  /** @type {NonNullable<import('../../types/sentry').TracingConfiguration>} */
+  const tracingOptions = merge(
+    {
       tracesSampleRate: 1.0,
       vueOptions: {
         tracing: true,
@@ -101,10 +106,11 @@ function resolveTracingOptions (options) {
         },
       },
       browserOptions: {},
-    }, typeof options.tracing === 'boolean' ? {} : options.tracing)
-    if (!options.config.tracesSampleRate) {
-      options.config.tracesSampleRate = options.tracing.tracesSampleRate
-    }
+    },
+    typeof tracing === 'boolean' ? {} : tracing,
+  )
+  if (tracingOptions && !config.tracesSampleRate) {
+    config.tracesSampleRate = tracingOptions.tracesSampleRate
   }
 }
 
@@ -118,11 +124,11 @@ export async function resolveClientOptions (moduleContainer, moduleOptions, logg
   /** @type {import('../../types/sentry').ResolvedModuleConfiguration} */
   const options = merge({}, moduleOptions)
 
-  options.clientConfig = merge({}, options.config, options.clientConfig)
+  options.config = merge({}, options.config, options.clientConfig)
 
   const apiMethods = await getApiMethods('@sentry/browser')
   resolveLazyOptions(options, apiMethods, logger)
-  resolveTracingOptions(options)
+  resolveTracingOptions(options.tracing, options.config)
 
   for (const name of Object.keys(options.clientIntegrations)) {
     if (!PLUGGABLE_INTEGRATIONS.includes(name) && !BROWSER_INTEGRATIONS.includes(name)) {
@@ -147,7 +153,7 @@ export async function resolveClientOptions (moduleContainer, moduleOptions, logg
     runtimeConfigKey: options.runtimeConfigKey,
     config: {
       dsn: options.dsn,
-      ...options.clientConfig,
+      ...options.config,
     },
     lazy: options.lazy,
     apiMethods,
@@ -202,22 +208,30 @@ export async function resolveServerOptions (moduleContainer, moduleOptions, logg
       ...customIntegrations,
     ],
   }
-  options.config = merge(defaultConfig, options.config, options.serverConfig)
 
-  const { publicRuntimeConfig } = moduleContainer.options
-  const { runtimeConfigKey } = options
-  if (typeof (publicRuntimeConfig) !== 'function' && runtimeConfigKey && runtimeConfigKey in publicRuntimeConfig) {
-    merge(options.config, publicRuntimeConfig[runtimeConfigKey].config, publicRuntimeConfig[runtimeConfigKey].serverConfig)
-  }
+  options.config = merge(defaultConfig, options.config, options.serverConfig, getRuntimeConfig(moduleContainer, options))
 
   const apiMethods = await getApiMethods('@sentry/node')
   resolveLazyOptions(options, apiMethods, logger)
-  resolveTracingOptions(options)
+  resolveTracingOptions(options.tracing, options.config)
 
   return {
     config: options.config,
     apiMethods,
     lazy: options.lazy,
     logMockCalls: options.logMockCalls, // for mocked only
+  }
+}
+
+/**
+ * @param {ThisParameterType<import('@nuxt/types').Module>} moduleContainer
+ * @param {import('../../types/sentry').ResolvedModuleConfiguration} options
+ * @return {import('../../types/sentry').ModuleConfiguration['config']}
+ */
+function getRuntimeConfig (moduleContainer, options) {
+  const { publicRuntimeConfig } = moduleContainer.options
+  const { runtimeConfigKey } = options
+  if (typeof (publicRuntimeConfig) !== 'function' && runtimeConfigKey in publicRuntimeConfig) {
+    return merge(options.config, publicRuntimeConfig[runtimeConfigKey].config, publicRuntimeConfig[runtimeConfigKey].serverConfig)
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@nuxtjs/eslint-config-typescript": "^11.0.0",
     "@nuxtjs/module-test-utils": "^1.6.3",
     "@release-it/conventional-changelog": "^5.1.0",
+    "@sentry/tracing": "^6.19.7",
     "@sentry/webpack-plugin": "^1.19.0",
     "@types/jest": "^29.0.3",
     "@types/lodash.mergewith": "^4.6.7",

--- a/types/sentry.d.ts
+++ b/types/sentry.d.ts
@@ -1,5 +1,5 @@
 import { Options as WebpackOptions } from 'webpack'
-import { BrowserTracingOptions } from '@sentry/tracing/dist/browser/browsertracing'
+import { BrowserTracing } from '@sentry/tracing'
 import { Options as SentryOptions } from '@sentry/types'
 import { BrowserOptions } from '@sentry/browser'
 import { SentryCliPluginOptions } from '@sentry/webpack-plugin'
@@ -45,7 +45,7 @@ export interface TracingConfiguration {
         tracing?: boolean
         tracingOptions?: Partial<TracingOptions>
     }
-    browserOptions?: Partial<BrowserTracingOptions>
+    browserOptions?: Partial<BrowserTracing['options']>
 }
 
 export interface ModuleConfiguration {

--- a/types/sentry.d.ts
+++ b/types/sentry.d.ts
@@ -43,9 +43,9 @@ export interface TracingConfiguration {
     tracesSampleRate?: number
     vueOptions?: {
         tracing?: boolean
-        tracingOptions?: TracingOptions
+        tracingOptions?: Partial<TracingOptions>
     }
-    browserOptions?: BrowserTracingOptions
+    browserOptions?: Partial<BrowserTracingOptions>
 }
 
 export interface ModuleConfiguration {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,6 +3259,17 @@
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
+"@sentry/tracing@^6.19.7":
+  version "6.19.7"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.19.7.tgz#54bb99ed5705931cd33caf71da347af769f02a4c"
+  integrity sha512-ol4TupNnv9Zd+bZei7B6Ygnr9N3Gp1PUrNI761QSlHtPC25xXC5ssSD3GMhBgyQrcvpuRcCFHVNNM97tN5cZiA==
+  dependencies:
+    "@sentry/hub" "6.19.7"
+    "@sentry/minimal" "6.19.7"
+    "@sentry/types" "6.19.7"
+    "@sentry/utils" "6.19.7"
+    tslib "^1.9.3"
+
 "@sentry/types@6.19.7":
   version "6.19.7"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.19.7.tgz#c6b337912e588083fc2896eb012526cf7cfec7c7"
@@ -14678,10 +14689,15 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tslib@^1.9.3:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.0.1, tslib@^2.1.0, tslib@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
After recent refactorings, the client side config was missing the `tracesSampleRate` default value if `tracing` was enabled, resulting in no tracing.

Fixes #447