### PR TITLE
fix(tracing): merge user's tracing configuration

### DIFF
--- a/lib/core/options.js
+++ b/lib/core/options.js
@@ -86,13 +86,14 @@ function resolveLazyOptions (options, apiMethods, logger) {
 }
 
 /**
- * @param {import('../../types/sentry').ModuleConfiguration['tracing']} tracing
+ * @param {import('../../types/sentry').ModuleConfiguration} options
  * @param {NonNullable<import('../../types/sentry').ModuleConfiguration['config']>} config
  */
-function resolveTracingOptions (tracing, config) {
-  if (!tracing) {
+function resolveTracingOptions (options, config) {
+  if (!options.tracing) {
     return
   }
+  const userOptions = typeof options.tracing === 'boolean' ? {} : options.tracing
   /** @type {NonNullable<import('../../types/sentry').TracingConfiguration>} */
   const tracingOptions = merge(
     {
@@ -107,11 +108,12 @@ function resolveTracingOptions (tracing, config) {
       },
       browserOptions: {},
     },
-    typeof tracing === 'boolean' ? {} : tracing,
+    userOptions,
   )
-  if (tracingOptions && !config.tracesSampleRate) {
+  if (!config.tracesSampleRate) {
     config.tracesSampleRate = tracingOptions.tracesSampleRate
   }
+  options.tracing = tracingOptions
 }
 
 /**
@@ -128,7 +130,7 @@ export async function resolveClientOptions (moduleContainer, moduleOptions, logg
 
   const apiMethods = await getApiMethods('@sentry/browser')
   resolveLazyOptions(options, apiMethods, logger)
-  resolveTracingOptions(options.tracing, options.config)
+  resolveTracingOptions(options, options.config)
 
   for (const name of Object.keys(options.clientIntegrations)) {
     if (!PLUGGABLE_INTEGRATIONS.includes(name) && !BROWSER_INTEGRATIONS.includes(name)) {
@@ -213,7 +215,7 @@ export async function resolveServerOptions (moduleContainer, moduleOptions, logg
 
   const apiMethods = await getApiMethods('@sentry/node')
   resolveLazyOptions(options, apiMethods, logger)
-  resolveTracingOptions(options.tracing, options.config)
+  resolveTracingOptions(options, options.config)
 
   return {
     config: options.config,

--- a/lib/plugin.client.js
+++ b/lib/plugin.client.js
@@ -1,6 +1,7 @@
 import VueLib from 'vue'
 import merge from 'lodash.mergewith'
 import * as Sentry from '@sentry/browser'
+<% if (options.tracing) { %>import { Integrations as TracingIntegrations } from '@sentry/tracing'<% } %>
 <%
 if (options.initialize) {
   let integrations = options.PLUGGABLE_INTEGRATIONS.filter(key => key in options.integrations)
@@ -14,9 +15,6 @@ const { <%= integrations.join(', ') %> } = Sentry.Integrations
 <%}
 }
 %>
-<% if (options.tracing) { %>
-import { Integrations as TracingIntegrations } from '@sentry/tracing'
-<% } %>
 
 // eslint-disable-next-line require-await
 export default async function (ctx, inject) {
@@ -54,7 +52,7 @@ export default async function (ctx, inject) {
     }).join(',\n    ')%>,
   ]
   <% if (options.tracing) { %>
-    config.integrations.push(<%= `new TracingIntegrations.BrowserTracing(${serialize(options.tracing.browserOptions)})` %>)
+  config.integrations.push(<%= `new TracingIntegrations.BrowserTracing(${serialize(options.tracing.browserOptions)})` %>)
   <% } %>
   <% if (options.customClientIntegrations) { %>
   const customIntegrations = await getCustomIntegrations(ctx)

--- a/lib/plugin.client.js
+++ b/lib/plugin.client.js
@@ -52,7 +52,7 @@ export default async function (ctx, inject) {
     }).join(',\n    ')%>,
   ]
   <% if (options.tracing) { %>
-  config.integrations.push(<%= `new TracingIntegrations.BrowserTracing(${serialize(options.tracing.browserOptions)})` %>)
+  config.integrations.push(<%= `new TracingIntegrations.BrowserTracing(${Object.keys(options.tracing.browserOptions).length ? serialize(options.tracing.browserOptions) : ''})` %>)
   <% } %>
   <% if (options.customClientIntegrations) { %>
   const customIntegrations = await getCustomIntegrations(ctx)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "lib/module.js",
   "types": "types/index.d.ts",
   "scripts": {
-    "dev:fixture": "node ./node_modules/nuxt/bin/nuxt.js -c ./test/fixture/lazy/nuxt.config.js",
+    "dev:fixture": "node ./node_modules/nuxt/bin/nuxt.js -c ./test/fixture/default/nuxt.config.js",
     "dev:fixture:build": "node ./node_modules/nuxt/bin/nuxt.js build -c ./test/fixture/default/nuxt.config.js",
     "dev:fixture:start": "node ./node_modules/nuxt/bin/nuxt.js start -c ./test/fixture/default/nuxt.config.js",
     "dev:generate": "nuxt generate -c ./test/fixture/default/nuxt.config.js --force-build",

--- a/test/fixture/default/nuxt.config.js
+++ b/test/fixture/default/nuxt.config.js
@@ -15,11 +15,13 @@ const config = {
     SentryModule,
   ],
   sentry: {
+    dsn: 'https://fe8b7df6ea7042f69d7a97c66c2934f7@sentry.io.nuxt/1429779',
     clientIntegrations: {
       // Integration from @Sentry/browser package.
       TryCatch: { eventTarget: false },
     },
     customClientIntegrations: '~/config/custom-client-integrations.js',
+    tracing: true,
     publishRelease: {
       authToken: 'fakeToken',
       org: 'MyCompany',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5332,15 +5332,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001097, caniuse-lite@^1.0.30001164, caniuse-lite@^1.0.30001228, caniuse-lite@^1.0.30001332:
-  version "1.0.30001342"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001342.tgz#87152b1e3b950d1fbf0093e23f00b6c8e8f1da96"
-  integrity sha512-bn6sOCu7L7jcbBbyNhLg0qzXdJ/PMbybZTH/BA6Roet9wxYRm6Tr9D0s0uhLkOZ6MSG+QU6txUgdpr3MXIVqjA==
-
-caniuse-lite@^1.0.30001400:
-  version "1.0.30001412"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz#30f67d55a865da43e0aeec003f073ea8764d5d7c"
-  integrity sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001097, caniuse-lite@^1.0.30001164, caniuse-lite@^1.0.30001228, caniuse-lite@^1.0.30001332, caniuse-lite@^1.0.30001400:
+  version "1.0.30001439"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz"
+  integrity sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
Original code did not resolve `options.tracing: true` to an object with default properties. This resulted in `Vue` integration getting those options:

```js
    new Vue({ Vue: VueLib, ...{"attachProps":true,"logErrors":false}}),
```

rather than:

```js
    new Vue({ Vue: VueLib, ...{"attachProps":true,"logErrors":false,"tracing":true,"tracingOptions":{"hooks":["mount","update"],"timeout":2000,"trackComponents":true}}}),
```

and likely Vue tracing not working.