### PR TITLE
fix: incorrect option name in the warning message

### DIFF
--- a/lib/core/options.js
+++ b/lib/core/options.js
@@ -144,7 +144,7 @@ export async function resolveClientOptions (moduleContainer, moduleOptions, logg
     if (typeof (options.customClientIntegrations) === 'string') {
       customClientIntegrations = moduleContainer.nuxt.resolver.resolveAlias(options.customClientIntegrations)
     } else {
-      logger.warn(`Invalid customServerIntegrations option. Expected a file path, got "${typeof (options.customClientIntegrations)}".`)
+      logger.warn(`Invalid customClientIntegrations option. Expected a file path, got "${typeof (options.customClientIntegrations)}".`)
     }
   }
 


### PR DESCRIPTION
The warning is referencing to customServerIntegrations instead of customClientIntegrations.