### PR TITLE
fix: gracefully handle Nuxt versions without Runtime Config

### DIFF
--- a/docs/content/en/sentry/options.md
+++ b/docs/content/en/sentry/options.md
@@ -123,6 +123,7 @@ Normally, just setting DSN would be enough.
 - Default: `sentry`
 - Specified object in Nuxt config in `publicRuntimeConfig[runtimeConfigKey]` will override some options at runtime. See documentation at https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-runtime-config/
 - Used to define the environment at runtime for example
+- See also [Runtime Config](/sentry/runtime-config) documentation.
 
 ### disabled
 

--- a/docs/content/en/sentry/runtime-config.md
+++ b/docs/content/en/sentry/runtime-config.md
@@ -28,3 +28,5 @@ publicRuntimeConfig: {
 ```
 
 You can customize the key that is used to access settings from `publicRuntimeConfig` by setting [`runtimeConfigKey`](/sentry/options#runtimeconfigkey) in the non-runtime options.
+
+This functionality is supported from Nuxt 2.13 and up.

--- a/lib/core/options.js
+++ b/lib/core/options.js
@@ -233,7 +233,7 @@ export async function resolveServerOptions (moduleContainer, moduleOptions, logg
 function getRuntimeConfig (moduleContainer, options) {
   const { publicRuntimeConfig } = moduleContainer.options
   const { runtimeConfigKey } = options
-  if (typeof (publicRuntimeConfig) !== 'function' && runtimeConfigKey in publicRuntimeConfig) {
+  if (publicRuntimeConfig && typeof (publicRuntimeConfig) !== 'function' && runtimeConfigKey in publicRuntimeConfig) {
     return merge(options.config, publicRuntimeConfig[runtimeConfigKey].config, publicRuntimeConfig[runtimeConfigKey].serverConfig)
   }
 }


### PR DESCRIPTION
Fixes #462