### PR TITLE
feat: support plugin path for clientConfig and serverConfig

### DIFF
--- a/docs/content/en/sentry/options.md
+++ b/docs/content/en/sentry/options.md
@@ -373,7 +373,7 @@ export default function () {
 - Default: `{}`
 - Sentry SDK [Basic Browser Options](https://docs.sentry.io/platforms/javascript/guides/vue/configuration/options/).
 - The specified keys will override common options set in the `config` key.
-- The value can be a string in which case it needs to be a file path (can use [webpack aliases](https://nuxtjs.org/docs/2.x/directory-structure/assets#aliases)) pointing to a javascript file whose default export (a function) returns the configuration object. This is necessary in case some of the options rely on imported values or can't be serialized. The function is passed the `Nuxt Context` argument and can be `async`. Example of how to enable [User Feedback](https://docs.sentry.io/platforms/javascript/enriching-events/user-feedback/) dialog:
+- The value can be a string in which case it needs to be a file path (can use [webpack aliases](https://nuxtjs.org/docs/2.x/directory-structure/assets#aliases)) pointing to a javascript file whose default export (a function) returns the configuration object. This is necessary in case some of the options rely on imported values or can't be serialized. The function is passed a `Nuxt Context` argument and can be `async`. Example of how to enable [User Feedback](https://docs.sentry.io/platforms/javascript/enriching-events/user-feedback/) dialog:
   ```js [~/config/sentry-client-config.js]
   import { showReportDialog } from '@sentry/vue'
 

--- a/docs/content/en/sentry/options.md
+++ b/docs/content/en/sentry/options.md
@@ -338,7 +338,7 @@ export default function () {
 
 ### config
 
-- Type: `Object` or `String`
+- Type: `Object`
 - Default:
   ```js
   {

--- a/docs/content/en/sentry/options.md
+++ b/docs/content/en/sentry/options.md
@@ -338,7 +338,7 @@ export default function () {
 
 ### config
 
-- Type: `Object`
+- Type: `Object` or `String`
 - Default:
   ```js
   {
@@ -354,15 +354,40 @@ export default function () {
 
 - Type: `Object`
 - Default: `{}`
-- Server-specific Sentry SDK options.
+- Sentry SDK [Basic Server Options](https://docs.sentry.io/platforms/node/configuration/options/).
 - The specified keys will override common options set in the `config` key.
+- The value can be a string in which case it needs to be a file path (can use [webpack aliases](https://nuxtjs.org/docs/2.x/directory-structure/assets#aliases)) pointing to a javascript file whose default export (a function) returns the configuration object. This is necessary in case some of the options rely on imported values or can't be serialized. The function can be `async`. Artificial example that switches out the `transport`:
+  ```js [~/config/sentry-server-config.js]
+  import { makeNodeTransport } from '@sentry/node'
+
+  export default function() {
+    return {
+      transport: makeNodeTransport,
+    }
+  }
+  ```
 
 ### clientConfig
 
-- Type: `Object`
+- Type: `Object` or `String`
 - Default: `{}`
-- Browser-specific Sentry SDK options.
+- Sentry SDK [Basic Browser Options](https://docs.sentry.io/platforms/javascript/guides/vue/configuration/options/).
 - The specified keys will override common options set in the `config` key.
+- The value can be a string in which case it needs to be a file path (can use [webpack aliases](https://nuxtjs.org/docs/2.x/directory-structure/assets#aliases)) pointing to a javascript file whose default export (a function) returns the configuration object. This is necessary in case some of the options rely on imported values or can't be serialized. The function is passed the `Nuxt Context` argument and can be `async`. Example of how to enable [User Feedback](https://docs.sentry.io/platforms/javascript/enriching-events/user-feedback/) dialog:
+  ```js [~/config/sentry-client-config.js]
+  import { showReportDialog } from '@sentry/vue'
+
+  export default function(context) {
+    return {
+      beforeSend (event, hint) {
+        if (event.exception) {
+          showReportDialog({ eventId: event.event_id })
+        }
+        return event
+      },
+    }
+  }
+  ```
 
 ### requestHandlerConfig
 

--- a/lib/core/options.js
+++ b/lib/core/options.js
@@ -119,8 +119,14 @@ function resolveTracingOptions (options, config) {
 export async function resolveClientOptions (moduleContainer, moduleOptions, logger) {
   /** @type {import('../../types/sentry').ResolvedModuleConfiguration} */
   const options = merge({}, moduleOptions)
+  options.config = merge({}, options.config)
 
-  options.config = merge({}, options.config, options.clientConfig)
+  let clientConfigPath
+  if (typeof (options.clientConfig) === 'string') {
+    clientConfigPath = moduleContainer.nuxt.resolver.resolveAlias(options.clientConfig)
+  } else {
+    options.config = merge(options.config, options.clientConfig)
+  }
 
   const apiMethods = await getApiMethods('@sentry/vue')
   resolveLazyOptions(options, apiMethods, logger)
@@ -151,6 +157,7 @@ export async function resolveClientOptions (moduleContainer, moduleOptions, logg
       dsn: options.dsn,
       ...options.config,
     },
+    clientConfigPath,
     lazy: options.lazy,
     apiMethods,
     customClientIntegrations,
@@ -186,9 +193,13 @@ export async function resolveServerOptions (moduleContainer, moduleOptions, logg
   let customIntegrations = []
   if (options.customServerIntegrations) {
     const resolvedPath = moduleContainer.nuxt.resolver.resolveAlias(options.customServerIntegrations)
-    customIntegrations = (await import(resolvedPath).then(m => m.default || m))()
-    if (!Array.isArray(customIntegrations)) {
-      logger.error(`Invalid value returned from customServerIntegrations plugin. Expected an array, got "${typeof (customIntegrations)}".`)
+    try {
+      customIntegrations = (await import(resolvedPath).then(m => m.default || m))()
+      if (!Array.isArray(customIntegrations)) {
+        logger.error(`Invalid value returned from customServerIntegrations plugin. Expected an array, got "${typeof (customIntegrations)}".`)
+      }
+    } catch (error) {
+      logger.error(`Error handling the customServerIntegrations plugin:\n${error}`)
     }
   }
 
@@ -205,7 +216,17 @@ export async function resolveServerOptions (moduleContainer, moduleOptions, logg
     ],
   }
 
-  options.config = merge(defaultConfig, options.config, options.serverConfig, getRuntimeConfig(moduleContainer, options))
+  let serverConfig = options.serverConfig
+  if (typeof (serverConfig) === 'string') {
+    const resolvedPath = moduleContainer.nuxt.resolver.resolveAlias(options.serverConfig)
+    try {
+      serverConfig = (await import(resolvedPath).then(m => m.default || m))()
+    } catch (error) {
+      logger.error(`Error handling the serverConfig plugin:\n${error}`)
+    }
+  }
+
+  options.config = merge(defaultConfig, options.config, serverConfig, getRuntimeConfig(moduleContainer, options))
 
   const apiMethods = await getApiMethods('@sentry/node')
   resolveLazyOptions(options, apiMethods, logger)

--- a/lib/plugin.client.js
+++ b/lib/plugin.client.js
@@ -7,6 +7,8 @@ if (options.initialize) {
   let integrations = options.PLUGGABLE_INTEGRATIONS.filter(key => key in options.integrations)
   if (integrations.length) {%>import { <%= integrations.join(', ') %> } from '@sentry/integrations'
 <%}
+  if (options.clientConfigPath) {%>import getClientConfig from '<%= options.clientConfigPath %>'
+<%}
   if (options.customClientIntegrations) {%>import getCustomIntegrations from '<%= options.customClientIntegrations %>'
 <%}
   integrations = options.BROWSER_INTEGRATIONS.filter(key => key in options.integrations)
@@ -60,6 +62,12 @@ export default async function (ctx, inject) {
   }))
   merge(config, vueOptions, tracingOptions)
   <% } %>
+
+  <% if (options.clientConfigPath) { %>
+  const clientConfig = await getClientConfig(ctx)
+  clientConfig ? merge(config, clientConfig) : console.error(`[@nuxtjs/sentry] Invalid value returned from the clientConfig plugin.`)
+  <% } %>
+
   <% if (options.customClientIntegrations) { %>
   const customIntegrations = await getCustomIntegrations(ctx)
   if (Array.isArray(customIntegrations)) {

--- a/lib/plugin.lazy.js
+++ b/lib/plugin.lazy.js
@@ -174,6 +174,12 @@ async function loadSentry (ctx, inject) {
   }))
   <% } %>
 
+  <% if (options.clientConfigPath) { %>
+  const clientConfig = (await import(/* <%= magicComments.join(', ') %> */ '<%= options.clientConfigPath %>').then(m => m.default || m))(ctx)
+  const { default: merge } = await import(/* <%= magicComments.join(', ') %> */ 'lodash.mergewith')
+  clientConfig ? merge(config, clientConfig) : console.error(`[@nuxtjs/sentry] Invalid value returned from the clientConfig plugin.`)
+  <% } %>
+
   <%if (options.customClientIntegrations) {%>
   const customIntegrations = (await import(/* <%= magicComments.join(', ') %> */ '<%= options.customClientIntegrations %>').then(m => m.default || m))(ctx)
   if (Array.isArray(customIntegrations)) {

--- a/types/sentry.d.ts
+++ b/types/sentry.d.ts
@@ -29,7 +29,7 @@ export interface TracingConfiguration extends Pick<SentryOptions, 'tracesSampleR
 }
 
 export interface ModuleConfiguration {
-    clientConfig?: Partial<SentryVueOptions>
+    clientConfig?: Partial<SentryVueOptions> | string
     clientIntegrations?: IntegrationsConfiguration
     config?: SentryOptions
     customClientIntegrations?: string
@@ -47,7 +47,7 @@ export interface ModuleConfiguration {
     /** See available options at https://github.com/getsentry/sentry-webpack-plugin */
     publishRelease?: boolean | Partial<SentryCliPluginOptions>
     runtimeConfigKey?: string
-    serverConfig?: SentryOptions
+    serverConfig?: SentryOptions | string
     serverIntegrations?: IntegrationsConfiguration
     sourceMapStyle?: WebpackOptions.Devtool
     requestHandlerConfig?: Handlers.RequestHandlerOptions


### PR DESCRIPTION
Adds support for passing a path to a plugin (file that exports a function) for `clientConfig` and `serverConfig` options. Allows to configure options that would otherwise be impossible to handle due to serialization of options that Nuxt requires.

Resolves #385
Resolves #410
Resolves #343
Resolves #226