### PR TITLE
feat: enable tree shaking of Sentry SDK debug code

### DIFF
--- a/lib/core/hooks.js
+++ b/lib/core/hooks.js
@@ -1,5 +1,6 @@
 import { resolve, posix } from 'path'
 import merge from 'lodash.mergewith'
+import { DefinePlugin } from 'webpack'
 import * as Sentry from '@sentry/node'
 import { canInitialize, clientSentryEnabled, envToBool, serverSentryEnabled } from './utils'
 import { resolveRelease, resolveClientOptions, resolveServerOptions } from './options'
@@ -41,6 +42,16 @@ export async function buildHook (moduleContainer, moduleOptions, logger) {
       fileName: RESOLVED_RELEASE_FILENAME,
       options: { release },
     })
+  }
+
+  // Tree shake debugging code if not running in dev mode and Sentry debug option is not enabled on the client.
+  if (!clientOptions.dev && !clientOptions.config.debug) {
+    moduleContainer.options.build.plugins = moduleContainer.options.build.plugins || []
+    moduleContainer.options.build.plugins.push(
+      new DefinePlugin({
+        __SENTRY_DEBUG__: 'false',
+      }),
+    )
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "dev:fixture:build": "node ./node_modules/nuxt/bin/nuxt.js build -c ./test/fixture/default/nuxt.config.js",
     "dev:fixture:start": "node ./node_modules/nuxt/bin/nuxt.js start -c ./test/fixture/default/nuxt.config.js",
     "dev:generate": "nuxt generate -c ./test/fixture/default/nuxt.config.js --force-build",
+    "analyze": "node ./node_modules/nuxt/bin/nuxt.js build --analyze -c ./test/fixture/default/nuxt.config.js",
     "lint": "eslint --ext .vue,.js,.ts .",
     "lint:fix": "eslint --ext .vue,.js,.ts . --fix",
     "lint:fixture": "eslint --ext .vue,.js --no-ignore 'test/fixture/*/.nuxt/sentry.*'",


### PR DESCRIPTION
This shaves off about 22KB of parsed (about 3KB gzipped) code.