### PR TITLE
fix: update list of allowed integrations and allow configuring them

### DIFF
--- a/docs/content/en/sentry/options.md
+++ b/docs/content/en/sentry/options.md
@@ -236,7 +236,8 @@ Note that the module sets the following defaults when publishing is enabled:
     RewriteFrames: {},
   }
   ```
-- Sentry by default also enables the following browser integrations: `InboundFilters`, `FunctionToString`, `TryCatch`, `Breadcrumbs`, `GlobalHandlers`, `LinkedErrors`, `Dedupe`, `HttpContext`.
+- Sentry by default also enables the following browser integrations: `Breadcrumbs`, `Dedupe`, `FunctionToString`, `GlobalHandlers`, `HttpContext`, `InboundFilters`, `LinkedErrors`, `TryCatch`.
+- When `tracing` option is enabled then the [Vue Router Instrumentation](https://docs.sentry.io/platforms/javascript/guides/vue/configuration/integrations/vue-router/) is also enabled.
 - The full list of client integrations that are supported: `Breadcrumbs`, `CaptureConsole`, `Debug`, `Dedupe`, `ExtraErrorData`, `FunctionToString`, `GlobalHandlers`, `HttpClient`, `HttpContext`, `InboundFilters`, `LinkedErrors`, `ReportingObserver`, `RewriteFrames`, `TryCatch`.
 - Integration options can be specified in the object value corresponding to the individual integration key.
 - To disable integration that is enabled by default, pass `false` as a value. For example to disable `ExtraErrorData` integration (only), set the option to:
@@ -258,9 +259,10 @@ Note that the module sets the following defaults when publishing is enabled:
     Dedupe: {},
     ExtraErrorData: {},
     RewriteFrames: {},
+    Transaction: {},
   }
   ```
-- Sentry by default also enables the following server integrations: `InboundFilters`, `FunctionToString`, `Console`, `Http`, `OnUncaughtException`, `OnUnhandledRejection`, `ContextLines`, `Context`, `Modules`, `RequestData`, `LinkedErrors`.
+- Sentry by default enables the following server integrations: `Console`, `ContextLines`, `Context`, `FunctionToString`, `Http`,  `InboundFilters`, `LinkedErrors`, `Modules`,`OnUncaughtException`, `OnUnhandledRejection`, `RequestData`.
 - The full list of server integrations that are supported includes the ones above plus: `CaptureConsole`, `Debug`, `Dedupe`, `ExtraErrorData`, `RewriteFrames`, `Transaction`.
 - Integration options can be specified in the object value corresponding to the individual integration key.
 - To disable integration that is enabled by default, pass `false` as a value. For example to disable `ExtraErrorData` integration (only), set the option to:
@@ -269,6 +271,7 @@ Note that the module sets the following defaults when publishing is enabled:
     Dedupe: {},
     ExtraErrorData: false,
     RewriteFrames: {},
+    Transaction: {},
   }
   ```
 - See also [Sentry Server Integrations](https://docs.sentry.io/platforms/node/configuration/integrations/) for more information on configuring each integration.

--- a/lib/core/options.js
+++ b/lib/core/options.js
@@ -1,12 +1,18 @@
 import merge from 'lodash.mergewith'
 // @ts-ignore
 import { relativeTo } from '@nuxt/utils'
-import * as Integrations from '@sentry/integrations'
+import { Integrations as ServerIntegrations } from '@sentry/node'
+import * as ServerPluggableIntegrations from '@sentry/integrations'
 import { canInitialize } from './utils'
 
-export const PLUGGABLE_INTEGRATIONS = ['CaptureConsole', 'Debug', 'Dedupe', 'ExtraErrorData', 'HttpClient', 'ReportingObserver', 'RewriteFrames']
-export const BROWSER_INTEGRATIONS = ['InboundFilters', 'FunctionToString', 'TryCatch', 'Breadcrumbs', 'GlobalHandlers', 'LinkedErrors', 'HttpContext']
-const SERVER_INTEGRATIONS = ['CaptureConsole', 'Debug', 'Dedupe', 'ExtraErrorData', 'RewriteFrames', 'Modules', 'Transaction']
+// Enabled by default in Vue - https://docs.sentry.io/platforms/javascript/guides/vue/configuration/integrations/default/
+export const BROWSER_INTEGRATIONS = ['Breadcrumbs', 'Dedupe', 'FunctionToString', 'GlobalHandlers', 'HttpContext', 'InboundFilters', 'LinkedErrors', 'TryCatch']
+// Optional in Vue - https://docs.sentry.io/platforms/javascript/guides/vue/configuration/integrations/plugin/
+export const BROWSER_PLUGGABLE_INTEGRATIONS = ['CaptureConsole', 'Debug', 'ExtraErrorData', 'HttpClient', 'ReportingObserver', 'RewriteFrames']
+// Enabled by default in Node.js - https://docs.sentry.io/platforms/node/configuration/integrations/default-integrations/
+const SERVER_INTEGRATIONS = ['Console', 'ContextLines', 'FunctionToString', 'Http', 'InboundFilters', 'LinkedErrors', 'LocalVariables', 'Modules', 'OnUncaughtException', 'OnUnhandledRejection', 'RequestData']
+// Optional in Node.js - https://docs.sentry.io/platforms/node/configuration/integrations/pluggable-integrations/
+const SERVER_PLUGGABLE_INTEGRATIONS = ['CaptureConsole', 'Debug', 'Dedupe', 'ExtraErrorData', 'RewriteFrames', 'Transaction']
 
 /** @param {import('../../types/sentry').IntegrationsConfiguration} integrations */
 const filterDisabledIntegrations = integrations => Object.keys(integrations).filter(key => integrations[key])
@@ -136,7 +142,7 @@ export async function resolveClientOptions (moduleContainer, moduleOptions, logg
   resolveTracingOptions(options, options.config)
 
   for (const name of Object.keys(options.clientIntegrations)) {
-    if (!PLUGGABLE_INTEGRATIONS.includes(name) && !BROWSER_INTEGRATIONS.includes(name)) {
+    if (![...BROWSER_INTEGRATIONS, ...BROWSER_PLUGGABLE_INTEGRATIONS].includes(name)) {
       logger.warn(`Sentry clientIntegration "${name}" is not recognized and will be ignored.`)
       delete options.clientIntegrations[name]
     }
@@ -153,8 +159,8 @@ export async function resolveClientOptions (moduleContainer, moduleOptions, logg
   }
 
   return {
-    PLUGGABLE_INTEGRATIONS,
     BROWSER_INTEGRATIONS,
+    BROWSER_PLUGGABLE_INTEGRATIONS,
     dev: moduleContainer.options.dev,
     runtimeConfigKey: options.runtimeConfigKey,
     config: {
@@ -188,7 +194,7 @@ export async function resolveServerOptions (moduleContainer, moduleOptions, logg
   const options = merge({}, moduleOptions)
 
   for (const name of Object.keys(options.serverIntegrations)) {
-    if (!SERVER_INTEGRATIONS.includes(name)) {
+    if (![...SERVER_INTEGRATIONS, ...SERVER_PLUGGABLE_INTEGRATIONS].includes(name)) {
       logger.warn(`Sentry serverIntegration "${name}" is not recognized and will be ignored.`)
       delete options.serverIntegrations[name]
     }
@@ -209,12 +215,21 @@ export async function resolveServerOptions (moduleContainer, moduleOptions, logg
 
   const defaultConfig = {
     dsn: options.dsn,
-    intergrations: [
+    integrations: [
       ...filterDisabledIntegrations(options.serverIntegrations)
         .map((name) => {
           const opt = options.serverIntegrations[name]
-          // @ts-ignore
-          return Object.keys(opt).length ? new Integrations[name](opt) : new Integrations[name]()
+          try {
+            if (SERVER_INTEGRATIONS.includes(name)) {
+              // @ts-ignore
+              return Object.keys(opt).length ? new ServerIntegrations[name](opt) : new ServerIntegrations[name]()
+            } else {
+              // @ts-ignore
+              return Object.keys(opt).length ? new ServerPluggableIntegrations[name](opt) : new ServerPluggableIntegrations[name]()
+            }
+          } catch (error) {
+            throw new Error(`Failed initializing server integration "${name}".\n${error}`)
+          }
         }),
       ...customIntegrations,
     ],

--- a/lib/plugin.client.js
+++ b/lib/plugin.client.js
@@ -5,7 +5,7 @@ import * as Sentry from '~@sentry/vue'
 <% if (options.tracing) { %>import { BrowserTracing } from '~@sentry/tracing'<% } %>
 <%
 if (options.initialize) {
-  let integrations = options.PLUGGABLE_INTEGRATIONS.filter(key => key in options.integrations)
+  let integrations = options.BROWSER_PLUGGABLE_INTEGRATIONS.filter(key => key in options.integrations)
   if (integrations.length) {%>import { <%= integrations.join(', ') %> } from '~@sentry/integrations'
 <%}
   if (options.clientConfigPath) {%>import getClientConfig from '<%= options.clientConfigPath %>'

--- a/lib/plugin.lazy.js
+++ b/lib/plugin.lazy.js
@@ -113,7 +113,7 @@ async function loadSentry (ctx, inject) {
   <% if (options.tracing) { %>const { BrowserTracing } = await import(/* <%= magicComments.join(', ') %> */ '~@sentry/tracing')<% } %>
   <%
   if (options.initialize) {
-    let integrations = options.PLUGGABLE_INTEGRATIONS.filter(key => key in options.integrations)
+    let integrations = options.BROWSER_PLUGGABLE_INTEGRATIONS.filter(key => key in options.integrations)
     if (integrations.length) {%>const { <%= integrations.join(', ') %> } = await import(/* <%= magicComments.join(', ') %> */ '~@sentry/integrations')
 <%  }
     integrations = options.BROWSER_INTEGRATIONS.filter(key => key in options.integrations)


### PR DESCRIPTION
Some integrations were missing from the list so it was not possible to configure or enable those.