### PR TITLE
fix(tracing): initialize server side tracing correctly

### DIFF
--- a/lib/core/hooks.js
+++ b/lib/core/hooks.js
@@ -169,6 +169,8 @@ export async function initializeServerSentry (moduleContainer, moduleOptions, se
     sentryHandlerProxy.errorHandler = Sentry.Handlers.errorHandler()
     sentryHandlerProxy.requestHandler = Sentry.Handlers.requestHandler(moduleOptions.requestHandlerConfig)
     if (serverOptions.tracing) {
+      // Triggers initialization of the tracing integration as a side effect.
+      await import('@sentry/tracing')
       sentryHandlerProxy.tracingHandler = Sentry.Handlers.tracingHandler()
     }
   }

--- a/lib/core/options.js
+++ b/lib/core/options.js
@@ -258,6 +258,7 @@ export async function resolveServerOptions (moduleContainer, moduleOptions, logg
     apiMethods,
     lazy: options.lazy,
     logMockCalls: options.logMockCalls, // for mocked only
+    tracing: options.tracing,
   }
 }
 


### PR DESCRIPTION
The `@sentry/tracing` package has to be imported so that some tracing extensions are added.
Also forgot to pass `tracing` option on the server so tracing was never enabled there.

Fixes #508