### PR TITLE
Removed misleading config child

### DIFF
--- a/docs/content/en/guide/setup.md
+++ b/docs/content/en/guide/setup.md
@@ -40,12 +40,10 @@ Then, add `@nuxtjs/sentry` to the `modules` section of `nuxt.config.js` and set 
   sentry: {
     dsn: '', // Enter your project's DSN.
     // Additional Module Options.
-    config: {
-      // Optional Sentry SDK configuration.
-      // Those options are shared by both the Browser and the Server instances.
-      // Browser-only and Server-only options should go
-      // into `clientConfig` and `serverConfig` objects respectively.
-    },
+    // Optional Sentry SDK configuration.
+    // Those options are shared by both the Browser and the Server instances.
+    // Browser-only and Server-only options should go
+    // into `clientConfig` and `serverConfig` objects respectively.
   }
 }
 ```


### PR DESCRIPTION
When reading the doc, it was unclear if it was necessary to give options into a `config` object.
After testing, the object is not necessary to be able to have it working properly.
All options should be at the root of the module configuration object.