### PR TITLE
fix: significantly reduce client bundle size

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -20,7 +20,7 @@ export async function buildHook (nuxt: Nuxt, moduleOptions: ModuleConfiguration,
 
   const templateDir = fileURLToPath(new URL('./templates', import.meta.url))
 
-  const pluginOptionClient = clientSentryEnabled(moduleOptions) ? (moduleOptions.lazy ? 'lazy' : 'client') : 'mocked'
+  const pluginOptionClient = clientSentryEnabled(moduleOptions) && canInitialize(moduleOptions) ? (moduleOptions.lazy ? 'lazy' : 'client') : 'mocked'
   const clientOptions: ResolvedClientOptions = defu({ config: { release } }, await resolveClientOptions(nuxt, moduleOptions, logger))
   addPluginTemplate({
     src: resolve(templateDir, `plugin.${pluginOptionClient}.js`),

--- a/src/options.ts
+++ b/src/options.ts
@@ -5,7 +5,6 @@ import { Integrations as ServerIntegrations } from '@sentry/node'
 import type Sentry from '@sentry/node'
 import * as PluggableIntegrations from '@sentry/integrations'
 import type { Options } from '@sentry/types'
-import type { NuxtOptions } from '@nuxt/types'
 import type { AllIntegrations, LazyConfiguration, TracingConfiguration } from './types/configuration'
 import type { ModuleConfiguration } from './types'
 import { Nuxt, resolveAlias } from './kit-shim'
@@ -104,14 +103,12 @@ function resolveLazyOptions (options: ModuleConfiguration, apiMethods: string[],
     } else if (Array.isArray(options.lazy.mockApiMethods)) {
       const mockMethods = options.lazy.mockApiMethods
       options.lazy.mockApiMethods = mockMethods.filter(method => apiMethods.includes(method))
-
       const notfoundMethods = mockMethods.filter(method => !apiMethods.includes(method))
       if (notfoundMethods.length) {
         logger.warn('Some specified methods to mock weren\'t found in @sentry/vue:', notfoundMethods)
       }
-
       if (!options.lazy.mockApiMethods.includes('captureException')) {
-      // always add captureException if a sentry mock is requested
+        // always add captureException if a sentry mock is requested
         options.lazy.mockApiMethods.push('captureException')
       }
     }

--- a/test/fixture/lazy/nuxt.config.cjs
+++ b/test/fixture/lazy/nuxt.config.cjs
@@ -13,8 +13,7 @@ const config = {
   ],
   sentry: {
     lazy: true,
-    // dsn: 'https://fe8b7df6ea7042f69d7a97c66c2934f7@sentry.io.nuxt/1429779',
-    config: {},
+    dsn: 'https://fe8b7df6ea7042f69d7a97c66c2934f7@sentry.io.nuxt/1429779',
     clientIntegrations: {
       // Integration from @Sentry/browser package.
       TryCatch: { eventTarget: false },


### PR DESCRIPTION
The `import * as Sentry from '~@sentry/vue'` has prevented tree shaking from working.

This results in about 221KB reduction when using `tracing` and a bit less when not using `tracing` (that's weird, yes, but looks like related to Sentry SDK itself).

Unfortunately it doesn't benefit when using `lazy` loading. Maybe there is a way to handle it using webpack's magic comments in https://github.com/nuxt-community/sentry-module/blob/994f333a8dfbc8cb4ecefbbc8042752d804b7f64/src/templates/plugin.lazy.js#L112-L112 but I haven't investigated at that point.

EDIT: There is a webpack magic comment [`webpackExports`](https://webpack.js.org/api/module-methods/) but it's only available from webpack 5.