### PR TITLE
fix(types): restore original client types which have more methods

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -154,7 +154,7 @@ export async function initializeServerSentry (nuxt: Nuxt, moduleOptions: ModuleC
       sentryHandlerProxy.tracingHandler = Sentry.Handlers.tracingHandler()
     }
 
-    process.sentry = Sentry.getCurrentHub().getClient() as Sentry.NodeClient
+    process.sentry = Sentry
   }
 }
 

--- a/src/templates/plugin.client.js
+++ b/src/templates/plugin.client.js
@@ -1,11 +1,11 @@
 /* eslint-disable import/order */
 import Vue from 'vue'
 import merge from '~lodash.mergewith'
+import * as Sentry from '~@sentry/vue'
 <%
-const vueImports = ['getCurrentHub', 'init', 'Integrations', ...(options.tracing ? ['vueRouterInstrumentation'] : [])]
-%>import { <%= vueImports.join(', ') %> } from '~@sentry/vue'
-<%
-if (options.tracing) {%>import { BrowserTracing } from '~@sentry/tracing'
+if (options.tracing) {
+%>import { BrowserTracing } from '~@sentry/tracing'
+import { vueRouterInstrumentation } from '~@sentry/vue'
 <%}
 let integrations = options.BROWSER_PLUGGABLE_INTEGRATIONS.filter(key => key in options.integrations)
 if (integrations.length) {%>import { <%= integrations.join(', ') %> } from '~@sentry/integrations'
@@ -16,7 +16,7 @@ if (options.customClientIntegrations) {%>import getCustomIntegrations from '<%= 
 <%}
 integrations = options.BROWSER_INTEGRATIONS.filter(key => key in options.integrations)
 if (integrations.length) {%>
-const { <%= integrations.join(', ') %> } = Integrations
+const { <%= integrations.join(', ') %> } = Sentry.Integrations
 <%}
 %>
 
@@ -79,8 +79,7 @@ export default async function (ctx, inject) {
   }
 
   /* eslint-enable object-curly-spacing, quote-props, quotes, key-spacing, comma-spacing */
-  init(config)
-  const sentryClient = getCurrentHub().getClient()
-  inject('sentry', sentryClient)
-  ctx.$sentry = sentryClient
+  Sentry.init(config)
+  inject('sentry', Sentry)
+  ctx.$sentry = Sentry
 }

--- a/src/types/extend.d.ts
+++ b/src/types/extend.d.ts
@@ -1,26 +1,30 @@
 import 'vue'
 import 'vuex'
 import '@nuxt/types'
-import { Client } from '@sentry/types'
+import * as SentryNode from '@sentry/node'
+import * as SentryTypes from '@sentry/core'
 import { PartialModuleConfiguration } from './configuration'
 
 export type ModulePublicRuntimeConfig = Pick<PartialModuleConfiguration, 'config' | 'clientConfig' | 'serverConfig'>
 
+type Sentry = typeof SentryTypes
+type NodeSentry = typeof SentryNode
+
 // add type to Vue context
 declare module 'vue/types/vue' {
   interface Vue {
-    readonly $sentry: Client
+    readonly $sentry: Sentry
     $sentryLoad(): Promise<void>
-    $sentryReady(): Promise<Client>
+    $sentryReady(): Promise<Sentry>
   }
 }
 
 // App Context and NuxtAppOptions
 declare module '@nuxt/types' {
   interface Context {
-    readonly $sentry: Client
+    readonly $sentry: Sentry
     $sentryLoad(): Promise<void>
-    $sentryReady(): Promise<Client>
+    $sentryReady(): Promise<Sentry>
   }
 
   interface NuxtOptions {
@@ -28,9 +32,9 @@ declare module '@nuxt/types' {
   }
 
   interface NuxtAppOptions {
-    readonly $sentry: Client
+    readonly $sentry: Sentry
     $sentryLoad(): Promise<void>
-    $sentryReady(): Promise<Client>
+    $sentryReady(): Promise<Sentry>
   }
 }
 
@@ -43,16 +47,16 @@ declare module '@nuxt/types/config/runtime' {
 // add types for Vuex Store
 declare module 'vuex/types' {
   interface Store<S> {
-    readonly $sentry: Client
+    readonly $sentry: Sentry
     $sentryLoad(): Promise<void>
-    $sentryReady(): Promise<Client>
+    $sentryReady(): Promise<Sentry>
   }
 }
 
 declare global {
   namespace NodeJS {
     interface Process {
-      sentry: Client
+      sentry: NodeSentry
     }
   }
 }

--- a/test/fixture/default/pages/index.vue
+++ b/test/fixture/default/pages/index.vue
@@ -14,6 +14,13 @@
 
 <script>
 export default {
+  asyncData ({ $sentry }) {
+    if (process.server) {
+      return {
+        serverSentryPresent: Boolean($sentry?.captureException),
+      }
+    }
+  },
   data () {
     return {
       clientSentryPresent: false,
@@ -21,9 +28,6 @@ export default {
     }
   },
   created () {
-    if (process.server) {
-      this.serverSentryPresent = Boolean(this.$sentry?.captureException)
-    }
     if (process.client) {
       this.clientSentryPresent = Boolean(this.$sentry?.captureException)
     }

--- a/test/fixture/lazy/pages/index.vue
+++ b/test/fixture/lazy/pages/index.vue
@@ -9,6 +9,13 @@
 
 <script>
 export default {
+  asyncData ({ $sentry }) {
+    if (process.server) {
+      return {
+        serverSentryPresent: Boolean($sentry?.captureException),
+      }
+    }
+  },
   data () {
     return {
       isSentryReady: false,
@@ -16,9 +23,6 @@ export default {
     }
   },
   created () {
-    if (process.server) {
-      this.serverSentryPresent = Boolean(this.$sentry?.captureException)
-    }
     if (process.client) {
       this.$sentryReady().then(() => {
         this.isSentryReady = true

--- a/test/fixture/with-lazy-config/pages/index.vue
+++ b/test/fixture/with-lazy-config/pages/index.vue
@@ -9,6 +9,13 @@
 
 <script>
 export default {
+  asyncData ({ $sentry }) {
+    if (process.server) {
+      return {
+        serverSentryPresent: Boolean($sentry?.captureException),
+      }
+    }
+  },
   data () {
     return {
       isSentryReady: false,
@@ -16,9 +23,6 @@ export default {
     }
   },
   created () {
-    if (process.server) {
-      this.serverSentryPresent = Boolean(this.$sentry?.captureException)
-    }
     if (process.client) {
       this.$sentryReady().then(() => {
         this.isSentryReady = true


### PR DESCRIPTION
Unfortunately the optimization done in #532 was not really correct as we need to expose more than just the Client in `process.sentry` or `$sentry`.

It can still be optimized by removing `@sentry/replay` when not used but that should ideally be fixed on the Sentry SDK side.