### PR TITLE
chore: publish to npm on release

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -28,6 +28,11 @@ export async function buildHook (nuxt: Nuxt, moduleOptions: ModuleConfiguration,
     mode: 'client',
     options: clientOptions,
   })
+  addTemplate({
+    src: resolve(templateDir, 'client.shared.js'),
+    filename: 'sentry.client.shared.js',
+    options: clientOptions,
+  })
 
   const pluginOptionServer = serverSentryEnabled(moduleOptions) ? 'server' : 'mocked'
   const serverOptions: ResolvedServerOptions = defu({ config: { release } }, await resolveServerOptions(nuxt, moduleOptions, logger))

--- a/src/module.ts
+++ b/src/module.ts
@@ -85,10 +85,18 @@ export default defineNuxtModule<ModuleConfiguration>({
     }
 
     // Work-around issues with Nuxt not being able to resolve unhoisted dependencies that are imported in webpack context.
-    const aliasedDependencies = ['lodash.mergewith', '@sentry/integrations', '@sentry/utils', '@sentry/vue', ...(options.tracing ? ['@sentry/tracing'] : [])]
+    const aliasedDependencies = [
+      'lodash.mergewith',
+      '@sentry/core',
+      '@sentry/integrations',
+      '@sentry/utils',
+      '@sentry/vue',
+      ...(options.tracing ? ['@sentry/tracing'] : []),
+    ]
     for (const dep of aliasedDependencies) {
       nuxt.options.alias[`~${dep}`] = (await resolvePath(dep)).replace(/\/cjs\//, '/esm/')
     }
+    nuxt.options.alias['~@sentry/browser-sdk'] = (await resolvePath('@sentry/browser/esm/sdk'))
 
     if (serverSentryEnabled(options)) {
       /**

--- a/src/options.ts
+++ b/src/options.ts
@@ -83,7 +83,7 @@ export async function resolveRelease (moduleOptions: ModuleConfiguration): Promi
   }
 }
 
-function resolveLazyOptions (options: ModuleConfiguration, apiMethods: string[], logger: Consola) {
+function resolveClientLazyOptions (options: ModuleConfiguration, apiMethods: string[], logger: Consola) {
   if (options.lazy) {
     const defaultLazyOptions = {
       injectMock: true,
@@ -170,7 +170,7 @@ export async function resolveClientOptions (nuxt: Nuxt, moduleOptions: ModuleCon
   }
 
   const apiMethods = await getApiMethods('@sentry/vue')
-  resolveLazyOptions(options, apiMethods, logger)
+  resolveClientLazyOptions(options, apiMethods, logger)
   resolveTracingOptions(options, config)
 
   for (const name of getIntegrationsKeys(options.clientIntegrations)) {
@@ -281,14 +281,11 @@ export async function resolveServerOptions (nuxt: Nuxt, moduleOptions: ModuleCon
   }
 
   const config = defu(defaultConfig, options.config, options.serverConfig, getRuntimeConfig(nuxt, options))
-
-  const apiMethods = await getApiMethods('@sentry/node')
-  resolveLazyOptions(options, apiMethods, logger)
   resolveTracingOptions(options, options.config)
 
   return {
     config,
-    apiMethods,
+    apiMethods: await getApiMethods('@sentry/node'),
     lazy: options.lazy,
     logMockCalls: options.logMockCalls, // for mocked only
     tracing: options.tracing,

--- a/src/templates/client.shared.js
+++ b/src/templates/client.shared.js
@@ -1,0 +1,87 @@
+<%
+if (options.clientConfigPath) {%>import getClientConfig from '<%= options.clientConfigPath %>'
+<%}
+if (options.customClientIntegrations) {%>import getCustomIntegrations from '<%= options.customClientIntegrations %>'
+<%}%>
+import merge from '~lodash.mergewith'
+<%
+const browserIntegrations = options.BROWSER_INTEGRATIONS.filter(key => key in options.integrations)
+const vueImports = [
+  'init',
+  ...(browserIntegrations.length ? ['Integrations'] : []),
+  ...(options.tracing ? ['vueRouterInstrumentation'] : [])
+]
+%>import { <%= vueImports.join(', ') %> } from '~@sentry/vue'
+import * as CoreSdk from '~@sentry/core'
+import * as BrowserSdk from '~@sentry/browser-sdk'
+<%
+if (options.tracing) {%>import { BrowserTracing } from '~@sentry/tracing'
+<%}
+let integrations = options.BROWSER_PLUGGABLE_INTEGRATIONS.filter(key => key in options.integrations)
+if (integrations.length) {%>import { <%= integrations.join(', ') %> } from '~@sentry/integrations'
+<%}%>
+
+export { init }
+export const SentrySdk = { ...CoreSdk, ...BrowserSdk }
+
+export<%= (options.clientConfigPath || options.customClientIntegrations) ? ' async' : '' %> function getConfig (ctx) {
+  /* eslint-disable object-curly-spacing, quote-props, quotes, key-spacing, comma-spacing */
+  const config = {
+    <%= Object
+      .entries(options.config)
+      .map(([key, option]) => {
+        const value = typeof option === 'function' ? serializeFunction(option) : serialize(option)
+        return `${key}:${value}`
+      })
+      .join(',\n    ') %>,
+  }
+
+  <% if (browserIntegrations.length) {%>
+  const { <%= browserIntegrations.join(', ') %> } = Integrations
+  <%}%>
+  config.integrations = [
+    <%= Object
+      .entries(options.integrations)
+      .filter(([name]) => name !== 'Vue')
+      .map(([name, integration]) => {
+        const integrationOptions = Object
+          .entries(integration)
+          .map(([key, option]) => {
+            const value = typeof option === 'function' ? serializeFunction(option) : serialize(option)
+            return `${key}:${value}`
+          })
+
+        return `new ${name}(${integrationOptions.length ? '{ ' + integrationOptions.join(',') + ' }' : ''})`
+      })
+      .join(',\n    ') %>,
+  ]
+  <% if (options.tracing) { %>
+  const { browserTracing, vueOptions, ...tracingOptions } = <%= serialize(options.tracing) %>
+  config.integrations.push(new BrowserTracing({
+    ...(ctx.app.router ? { routingInstrumentation: vueRouterInstrumentation(ctx.app.router) } : {}),
+    ...browserTracing,
+  }))
+  merge(config, vueOptions, tracingOptions)
+  <% } %>
+
+  <% if (options.clientConfigPath) { %>
+  const clientConfig = await getClientConfig(ctx)
+  clientConfig ? merge(config, clientConfig) : console.error(`[@nuxtjs/sentry] Invalid value returned from the clientConfig plugin.`)
+  <% } %>
+
+  <% if (options.customClientIntegrations) { %>
+  const customIntegrations = await getCustomIntegrations(ctx)
+  if (Array.isArray(customIntegrations)) {
+    config.integrations.push(...customIntegrations)
+  } else {
+    console.error(`[@nuxtjs/sentry] Invalid value returned from customClientIntegrations plugin. Expected an array, got "${typeof customIntegrations}".`)
+  }
+  <% } %>
+
+  const runtimeConfigKey = <%= serialize(options.runtimeConfigKey) %>
+  if (ctx.$config && runtimeConfigKey && ctx.$config[runtimeConfigKey]) {
+    merge(config, ctx.$config[runtimeConfigKey].config, ctx.$config[runtimeConfigKey].clientConfig)
+  }
+
+  return config
+}

--- a/src/templates/plugin.client.js
+++ b/src/templates/plugin.client.js
@@ -1,85 +1,9 @@
-/* eslint-disable import/order */
 import Vue from 'vue'
-import merge from '~lodash.mergewith'
-import * as Sentry from '~@sentry/vue'
-<%
-if (options.tracing) {
-%>import { BrowserTracing } from '~@sentry/tracing'
-import { vueRouterInstrumentation } from '~@sentry/vue'
-<%}
-let integrations = options.BROWSER_PLUGGABLE_INTEGRATIONS.filter(key => key in options.integrations)
-if (integrations.length) {%>import { <%= integrations.join(', ') %> } from '~@sentry/integrations'
-<%}
-if (options.clientConfigPath) {%>import getClientConfig from '<%= options.clientConfigPath %>'
-<%}
-if (options.customClientIntegrations) {%>import getCustomIntegrations from '<%= options.customClientIntegrations %>'
-<%}
-integrations = options.BROWSER_INTEGRATIONS.filter(key => key in options.integrations)
-if (integrations.length) {%>
-const { <%= integrations.join(', ') %> } = Sentry.Integrations
-<%}
-%>
+import { getConfig, init, SentrySdk } from './sentry.client.shared'
 
 export default async function (ctx, inject) {
-  /* eslint-disable object-curly-spacing, quote-props, quotes, key-spacing, comma-spacing */
-  const config = {
-    Vue,
-    <%= Object
-      .entries(options.config)
-      .map(([key, option]) => {
-        const value = typeof option === 'function' ? serializeFunction(option) : serialize(option)
-        return `${key}:${value}`
-      })
-      .join(',\n    ') %>,
-  }
-
-  config.integrations = [
-    <%= Object
-      .entries(options.integrations)
-      .filter(([name]) => name !== 'Vue')
-      .map(([name, integration]) => {
-        const integrationOptions = Object
-          .entries(integration)
-          .map(([key, option]) => {
-            const value = typeof option === 'function' ? serializeFunction(option) : serialize(option)
-            return `${key}:${value}`
-          })
-
-        return `new ${name}(${integrationOptions.length ? '{ ' + integrationOptions.join(',') + ' }' : ''})`
-      })
-      .join(',\n    ') %>,
-  ]
-  <% if (options.tracing) { %>
-  // eslint-disable-next-line prefer-regex-literals
-  const { browserTracing, vueOptions, ...tracingOptions } = <%= serialize(options.tracing) %>
-  config.integrations.push(new BrowserTracing({
-    ...(ctx.app.router ? { routingInstrumentation: vueRouterInstrumentation(ctx.app.router) } : {}),
-    ...browserTracing,
-  }))
-  merge(config, vueOptions, tracingOptions)
-  <% } %>
-
-  <% if (options.clientConfigPath) { %>
-  const clientConfig = await getClientConfig(ctx)
-  clientConfig ? merge(config, clientConfig) : console.error(`[@nuxtjs/sentry] Invalid value returned from the clientConfig plugin.`)
-  <% } %>
-
-  <% if (options.customClientIntegrations) { %>
-  const customIntegrations = await getCustomIntegrations(ctx)
-  if (Array.isArray(customIntegrations)) {
-    config.integrations.push(...customIntegrations)
-  } else {
-    console.error(`[@nuxtjs/sentry] Invalid value returned from customClientIntegrations plugin. Expected an array, got "${typeof customIntegrations}".`)
-  }
-  <% } %>
-
-  const runtimeConfigKey = <%= serialize(options.runtimeConfigKey) %>
-  if (ctx.$config && runtimeConfigKey && ctx.$config[runtimeConfigKey]) {
-    merge(config, ctx.$config[runtimeConfigKey].config, ctx.$config[runtimeConfigKey].clientConfig)
-  }
-
-  /* eslint-enable object-curly-spacing, quote-props, quotes, key-spacing, comma-spacing */
-  Sentry.init(config)
-  inject('sentry', Sentry)
-  ctx.$sentry = Sentry
+  const config = await getConfig(ctx)
+  init({ Vue, ...config })
+  inject('sentry', SentrySdk)
+  ctx.$sentry = SentrySdk
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
   "exclude": [
     "./dist",
     "./node_modules/",
+    "./src/templates/client.*.js",
     "./src/templates/plugin.*.js",
   ]
 }


### PR DESCRIPTION
The `import * as Sentry from '~@sentry/vue'` has prevented tree shaking from working.

Second attempt. This time also handling `lazy` and exposing all relevant SDK methods on `$sentry`.

Gzipped savings for the whole client bundle for this module's test fixture:
 - Non-lazy: 208kb -> 140kb
 - Lazy: 430kb -> 340kb

Also greatly reduces duplicated code in lazy and non-lazy plugins, simplifying maintenance. The code of those two was already slightly out of sync.