### PR TITLE
fix: shutdown sentry after Nuxt build is done

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -142,11 +142,12 @@ export default defineNuxtModule<ModuleConfiguration>({
       // the release version has been determined and the options template created but before
       // the build is started (if building).
       if (isNuxt2()) {
-        const initHook = nuxt.options._build ? 'build:compile' : 'ready'
+        const isBuilding = nuxt.options._build
+        const initHook = isBuilding ? 'build:compile' : 'ready'
         nuxt.hook(initHook, () => initializeServerSentry(nuxt, options, sentryHandlerProxy, logger))
+        const shutdownHook = isBuilding ? 'build:done' : 'close'
         const shutdownServerSentryOnce = callOnce(() => shutdownServerSentry())
-        nuxt.hook('generate:done', shutdownServerSentryOnce)
-        nuxt.hook('close', shutdownServerSentryOnce)
+        nuxt.hook(shutdownHook, shutdownServerSentryOnce)
       }
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
     "./test/",
   ],
   "exclude": [
-    "./dist",
+    "**/dist",
     "./node_modules/",
     "./src/templates/client.*.js",
     "./src/templates/plugin.*.js",


### PR DESCRIPTION
Prevent Nuxt warning about not being able to exit after building.