### PR TITLE
fix: don't shutdown Sentry SDK after build in dev mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    name: Use Node.js ${{ matrix.node-version }}
+    name: Lint and test
     runs-on: ubuntu-latest
     env:
       CI: true

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -149,6 +149,8 @@ export async function initializeServerSentry (nuxt: Nuxt, moduleOptions: ModuleC
   const serverOptions = await resolveServerOptions(nuxt, moduleOptions, logger)
   const config: Options = defu({ release }, serverOptions.config)
 
+  process.sentry = Sentry
+
   if (canInitialize(moduleOptions)) {
     Sentry.init(config)
     sentryHandlerProxy.errorHandler = Sentry.Handlers.errorHandler()
@@ -156,8 +158,6 @@ export async function initializeServerSentry (nuxt: Nuxt, moduleOptions: ModuleC
     if (serverOptions.tracing) {
       sentryHandlerProxy.tracingHandler = Sentry.Handlers.tracingHandler()
     }
-
-    process.sentry = Sentry
   }
 }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -141,7 +141,7 @@ export default defineNuxtModule<ModuleConfiguration>({
       // the release version has been determined and the options template created but before
       // the build is started (if building).
       if (isNuxt2()) {
-        const isBuilding = nuxt.options._build
+        const isBuilding = nuxt.options._build && !nuxt.options.dev
         const initHook = isBuilding ? 'build:compile' : 'ready'
         nuxt.hook(initHook, () => initializeServerSentry(nuxt, options, sentryHandlerProxy, logger))
         const shutdownHook = isBuilding ? 'build:done' : 'close'


### PR DESCRIPTION
Don't shutdown Sentry SDK after build in dev mode and also expose Sentry SDK on the server on the `process.sentry` regardless if initializing SDK or not. This is how it worked before and was changed later for reasons that were later reversed anyway so this change should be reversed too.