### PR TITLE
fix: only include 'crash' type for `ReportingObserver` integration

### DIFF
--- a/docs/content/en/configuration/options.md
+++ b/docs/content/en/configuration/options.md
@@ -232,7 +232,7 @@ Note that the module sets the following defaults when publishing is enabled:
   ```js
   {
     ExtraErrorData: {},
-    ReportingObserver: {},
+    ReportingObserver: { types: ['crash'] },
     RewriteFrames: {},
   }
   ```
@@ -244,8 +244,6 @@ Note that the module sets the following defaults when publishing is enabled:
   ```js
   {
     ExtraErrorData: false,
-    ReportingObserver: {},
-    RewriteFrames: {},
   }
   ```
 - See also [Sentry Browser Integrations](https://docs.sentry.io/platforms/javascript/guides/vue/configuration/integrations/) for more information on configuring each integration.
@@ -268,10 +266,7 @@ Note that the module sets the following defaults when publishing is enabled:
 - To disable integration that is enabled by default, pass `false` as a value. For example to disable `ExtraErrorData` integration (only) set the option to:
   ```js
   {
-    Dedupe: {},
     ExtraErrorData: false,
-    RewriteFrames: {},
-    Transaction: {},
   }
   ```
 - See also [Sentry Server Integrations](https://docs.sentry.io/platforms/node/configuration/integrations/) for more information on configuring each integration.

--- a/src/module.ts
+++ b/src/module.ts
@@ -37,7 +37,7 @@ export default defineNuxtModule<ModuleConfiguration>({
     tracing: false,
     clientIntegrations: {
       ExtraErrorData: {},
-      ReportingObserver: {},
+      ReportingObserver: { types: ['crash'] },
       RewriteFrames: {},
     },
     serverIntegrations: {


### PR DESCRIPTION
I'm not sure why we even enable `ReportingObserver` integration by default since it seems to produce a lot of reports that are not really that useful. But instead of removing it completely, only include the `crash` report types (so exclude `deprecation` and `intervention` by default) to keep those reports to minimum.