### PR TITLE
chore(docs): update typos in Session Replay page

### DIFF
--- a/docs/content/en/guide/session-replay.md
+++ b/docs/content/en/guide/session-replay.md
@@ -15,7 +15,7 @@ Session Replay comes as a separate integration that is not enabled by default. T
 sentry: {
   dsn: '...',
   clientIntegrations: [
-    Reply: {},
+    Replay: {},
   ],
   clientConfig: {
     // This sets the sample rate to be 10%. You may want this to be 100% while

--- a/docs/content/en/guide/session-replay.md
+++ b/docs/content/en/guide/session-replay.md
@@ -14,9 +14,9 @@ Session Replay comes as a separate integration that is not enabled by default. T
 ```js [nuxt.config.js]
 sentry: {
   dsn: '...',
-  clientIntegrations: [
+  clientIntegrations: {
     Replay: {},
-  ],
+  },
   clientConfig: {
     // This sets the sample rate to be 10%. You may want this to be 100% while
     // in development and sample at a lower rate in production


### PR DESCRIPTION
Updated documentation to use `Replay` as the client integration key, not `Reply`