### PR TITLE
fix: remove use of unctx to avoid issues with conflicting versions

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -22,7 +22,6 @@ export default defineBuildConfig({
     'hash-sum',
     'hookable',
     'pathe',
-    'unctx',
     'webpack',
     'vuex',
   ],

--- a/package.json
+++ b/package.json
@@ -69,8 +69,7 @@
     "hash-sum": "^2.0.0",
     "lodash.mergewith": "^4.6.2",
     "mlly": "^1.0.0",
-    "pathe": "^1.0.0",
-    "unctx": "^2.0.0"
+    "pathe": "^1.0.0"
   },
   "devDependencies": {
     "@nuxt/module-builder": "0.2.1",

--- a/src/kit-shim.ts
+++ b/src/kit-shim.ts
@@ -7,7 +7,6 @@ import hash from 'hash-sum'
 import { basename, parse, normalize, resolve } from 'pathe'
 import { resolveAlias as _resolveAlias } from 'pathe/utils'
 import type { Hookable } from 'hookable'
-import { getContext } from 'unctx'
 import type { WebpackPluginInstance, Configuration as WebpackConfig } from 'webpack'
 import type { NuxtOptions } from '@nuxt/types'
 
@@ -58,7 +57,7 @@ export interface NuxtModule<T extends ModuleOptions = ModuleOptions> {
 }
 
 /** Direct access to the Nuxt context - see https://github.com/unjs/unctx. */
-export const nuxtCtx = getContext<Nuxt>('nuxt')
+let nuxtCtx: Nuxt | null = null
 
 // TODO: Use use/tryUse from unctx. https://github.com/unjs/unctx/issues/6
 
@@ -73,7 +72,7 @@ export const nuxtCtx = getContext<Nuxt>('nuxt')
  * ```
  */
 export function useNuxt (): Nuxt {
-  const instance = nuxtCtx.tryUse()
+  const instance = nuxtCtx
   if (!instance) {
     throw new Error('Nuxt instance is unavailable!')
   }
@@ -94,7 +93,7 @@ export function useNuxt (): Nuxt {
  * ```
  */
 export function tryUseNuxt (): Nuxt | null {
-  return nuxtCtx.tryUse()
+  return nuxtCtx
 }
 
 // -- Nuxt 2 compatibility shims --
@@ -111,9 +110,9 @@ function nuxt2Shims (nuxt: Nuxt) {
   nuxt.hooks = nuxt
 
   // Allow using useNuxt()
-  if (!nuxtCtx.tryUse()) {
-    nuxtCtx.set(nuxt)
-    nuxt.hook('close', () => nuxtCtx.unset())
+  if (!nuxtCtx) {
+    nuxtCtx = nuxt
+    nuxt.hook('close', () => { nuxtCtx = null })
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6089,13 +6089,6 @@ estree-walker@^2.0.2:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
-estree-walker@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
-  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
-  dependencies:
-    "@types/estree" "^1.0.0"
-
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -12928,16 +12921,6 @@ unbuild@^1.0.1:
     typescript "^4.9.5"
     untyped "^1.2.2"
 
-unctx@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/unctx/-/unctx-2.1.2.tgz#12d34c540ef4fbaffb2a3b38a0697e42b152d478"
-  integrity sha512-KK18aLRKe3OlbPyHbXAkIWSU3xK8GInomXfA7fzDMGFXQ1crX1UWrCzKesVXeUyHIayHUrnTvf87IPCKMyeKTg==
-  dependencies:
-    acorn "^8.8.2"
-    estree-walker "^3.0.3"
-    magic-string "^0.27.0"
-    unplugin "^1.0.1"
-
 unfetch@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-5.0.0.tgz#8a5b6e5779ebe4dde0049f7d7a81d4a1af99d142"
@@ -13016,16 +12999,6 @@ unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
-
-unplugin@^1.0.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/unplugin/-/unplugin-1.3.1.tgz#7af993ba8695d17d61b0845718380caf6af5109f"
-  integrity sha512-h4uUTIvFBQRxUKS2Wjys6ivoeofGhxzTe2sRWlooyjHXVttcVfV/JiavNd3d4+jty0SVV0dxGw9AkY9MwiaCEw==
-  dependencies:
-    acorn "^8.8.2"
-    chokidar "^3.5.3"
-    webpack-sources "^3.2.3"
-    webpack-virtual-modules "^0.5.0"
 
 unset-value@^1.0.0:
   version "1.0.0"
@@ -13433,15 +13406,10 @@ webpack-sources@^1.0.1, webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-"webpack-sources@^2.0.0 || ^3.0.0", webpack-sources@^3.2.3:
+"webpack-sources@^2.0.0 || ^3.0.0":
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
-
-webpack-virtual-modules@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz#362f14738a56dae107937ab98ea7062e8bdd3b6c"
-  integrity sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==
 
 webpack@^4.46.0:
   version "4.46.0"


### PR DESCRIPTION
I suppose I could have fixed it by using different context name than `nuxt` but there is not really any need for this package since the context is not even used outside of a single file.

Fixes #557