### PR TITLE
fix: crash on handling unhandled exceptions

### DIFF
--- a/src/templates/plugin.lazy.js
+++ b/src/templates/plugin.lazy.js
@@ -18,7 +18,13 @@ const delayGlobalError = function (event) {
   delayedGlobalErrors.push([event.message, event.filename, event.lineno, event.colno, event.error])
 }
 const delayUnhandledRejection = function (event) {
-  delayedUnhandledRejections.push('reason' in event ? event.reason : 'detail' in event && 'reason' in event.detail ? event.detail.reason : event)
+  if ('reason' in event && event.reason) {
+    event = event.reason
+  }
+  if ('detail' in event && event.detail && 'reason' in event.detail && event.detail.reason) {
+    event = event.detail.reason
+  }
+  delayedUnhandledRejections.push(event)
 }
 
 const vueErrorHandler = Vue.config.errorHandler

--- a/src/templates/plugin.lazy.js
+++ b/src/templates/plugin.lazy.js
@@ -20,8 +20,7 @@ const delayGlobalError = function (event) {
 const delayUnhandledRejection = function (event) {
   if ('reason' in event && event.reason) {
     event = event.reason
-  }
-  if ('detail' in event && event.detail && 'reason' in event.detail && event.detail.reason) {
+  } else if ('detail' in event && event.detail && 'reason' in event.detail && event.detail.reason) {
     event = event.detail.reason
   }
   delayedUnhandledRejections.push(event)


### PR DESCRIPTION
I've noticed that this code can crash on checking `'reason' in event.detail` because `in` check crashes when the right-hand side is `undefined`.

See also the corresponding Sentry SDK issue: https://github.com/getsentry/sentry-javascript/issues/9579