### PR TITLE
fix: don't enable RewriteFrames integration by default

### DIFF
--- a/docs/content/en/configuration/options.md
+++ b/docs/content/en/configuration/options.md
@@ -220,7 +220,6 @@ sentry: {
   {
     ExtraErrorData: {},
     ReportingObserver: { types: ['crash'] },
-    RewriteFrames: {},
   }
   ```
 - Sentry by default also enables the following browser integrations: `Breadcrumbs`, `Dedupe`, `FunctionToString`, `GlobalHandlers`, `HttpContext`, `InboundFilters`, `LinkedErrors`, `TryCatch`.
@@ -243,7 +242,6 @@ sentry: {
   {
     Dedupe: {},
     ExtraErrorData: {},
-    RewriteFrames: {},
     Transaction: {},
   }
   ```

--- a/src/module.ts
+++ b/src/module.ts
@@ -38,12 +38,10 @@ export default defineNuxtModule<ModuleConfiguration>({
     clientIntegrations: {
       ExtraErrorData: {},
       ReportingObserver: { types: ['crash'] },
-      RewriteFrames: {},
     },
     serverIntegrations: {
       Dedupe: {},
       ExtraErrorData: {},
-      RewriteFrames: {},
       Transaction: {},
     },
     customClientIntegrations: '',

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -35,7 +35,6 @@ describe('Resolve Client Options', () => {
       integrations: {
         ExtraErrorData: {},
         ReportingObserver: {},
-        RewriteFrames: {},
       },
       lazy: false,
       logMockCalls: true,
@@ -72,7 +71,6 @@ describe('Resolve Client Options', () => {
       integrations: {
         ExtraErrorData: {},
         ReportingObserver: {},
-        RewriteFrames: {},
       },
       lazy: false,
       logMockCalls: true,
@@ -162,7 +160,7 @@ describe('Resolve Server Options', () => {
     })
     const integrations = Array.isArray(resolvedOptions.config.integrations) ? resolvedOptions.config.integrations : null
     expect(integrations).toBeTruthy()
-    expect(integrations?.map(integration => integration.name)).toEqual(expect.arrayContaining(['Http', 'Dedupe', 'ExtraErrorData', 'RewriteFrames', 'Transaction']))
+    expect(integrations?.map(integration => integration.name)).toEqual(expect.arrayContaining(['Http', 'Dedupe', 'ExtraErrorData', 'Transaction']))
   })
 
   test('can override tracesSampleRate', async () => {

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -117,7 +117,7 @@ describe('Resolve Server Options', () => {
     })
     const integrations = Array.isArray(resolvedOptions.config.integrations) ? resolvedOptions.config.integrations : null
     expect(integrations).toBeTruthy()
-    expect(integrations?.map(integration => integration.name)).toEqual(expect.arrayContaining(['Dedupe', 'ExtraErrorData', 'RewriteFrames', 'Transaction']))
+    expect(integrations?.map(integration => integration.name)).toEqual(expect.arrayContaining(['Dedupe', 'ExtraErrorData', 'Transaction']))
   })
 
   test('can override dsn in serverConfig', async () => {


### PR DESCRIPTION
After inspecting some crashes manually I've realized that the `RewriteFrames` integration that the module enables by default does more harm than good.

In case there are source maps it doesn't really make any difference since stack frame paths are resolved from source maps then.

In case there are no source maps (for example when crash is within the server code and not inside the webpack context) then what `RewriteFrames` does is it [strips the whole path leaving just the file name](https://github.com/getsentry/sentry-javascript/blob/45692f4e80c49bf8aca77695e12313ee24ca8bae/packages/integrations/src/rewriteframes.ts#L83-L83). That can result in just `index.js` being shown, for example, which makes it unclear which file is being referred to.

Decided to not enable this integration by default as a fix rather than a breaking change.

It can easily be re-added manually and ideally with the `root` option specified to just strip the app's root path. And maybe shouldn't be added on the client side since on the client side the source maps should make it redundant.