### PR TITLE
fix: set `root` for RewriteFrames integration

### DIFF
--- a/docs/content/en/configuration/options.md
+++ b/docs/content/en/configuration/options.md
@@ -220,7 +220,6 @@ sentry: {
   {
     ExtraErrorData: {},
     ReportingObserver: { types: ['crash'] },
-    RewriteFrames: {},
   }
   ```
 - Sentry by default also enables the following browser integrations: `Breadcrumbs`, `Dedupe`, `FunctionToString`, `GlobalHandlers`, `HttpContext`, `InboundFilters`, `LinkedErrors`, `TryCatch`.
@@ -243,7 +242,7 @@ sentry: {
   {
     Dedupe: {},
     ExtraErrorData: {},
-    RewriteFrames: {},
+    RewriteFrames: { root: <rootDir> },
     Transaction: {},
   }
   ```

--- a/src/module.ts
+++ b/src/module.ts
@@ -38,12 +38,11 @@ export default defineNuxtModule<ModuleConfiguration>({
     clientIntegrations: {
       ExtraErrorData: {},
       ReportingObserver: { types: ['crash'] },
-      RewriteFrames: {},
     },
     serverIntegrations: {
       Dedupe: {},
       ExtraErrorData: {},
-      RewriteFrames: {},
+      RewriteFrames: { root: nuxt.options.rootDir },
       Transaction: {},
     },
     customClientIntegrations: '',

--- a/test/fixture/typescript/api/index.ts
+++ b/test/fixture/typescript/api/index.ts
@@ -1,0 +1,7 @@
+import type { ServerMiddleware } from '@nuxt/types'
+
+export default <ServerMiddleware> function serverRoute (req, res, next) {
+  // @ts-expect-error crash on purpose
+  apiCrash()
+  res.end('OK')
+}

--- a/test/fixture/typescript/config/custom-client-integrations.ts
+++ b/test/fixture/typescript/config/custom-client-integrations.ts
@@ -1,6 +1,5 @@
 import type { Context } from '@nuxt/types'
-import type { ModuleOptions } from 'src/types'
 
-export default function (_context: Context): ModuleOptions['clientIntegrations'] {
-  return {}
+export default function (_context: Context): unknown[] {
+  return []
 }

--- a/test/fixture/typescript/nuxt.config.ts
+++ b/test/fixture/typescript/nuxt.config.ts
@@ -19,6 +19,9 @@ const config: NuxtConfig = {
   modules: [
     jiti.resolve('../../..'),
   ],
+  publicRuntimeConfig: {
+    baseURL: 'http://localhost:3000',
+  },
   sentry: {
     dsn: 'https://fe8b7df6ea7042f69d7a97c66c2934f7@sentry.io.nuxt/1429779',
     clientIntegrations: {
@@ -38,6 +41,9 @@ const config: NuxtConfig = {
     serverConfig: '~/config/server.config',
     tracing: true,
   },
+  serverMiddleware: [
+    { path: '/api', handler: '~/api/index' },
+  ],
   typescript: {
     typeCheck: false,
   },

--- a/test/fixture/typescript/pages/index.vue
+++ b/test/fixture/typescript/pages/index.vue
@@ -16,11 +16,14 @@
 import { defineComponent } from 'vue'
 
 export default defineComponent({
-  asyncData ({ $sentry, query }) {
+  async asyncData ({ $sentry, $config, query }) {
     if (query.crashOnLoad) {
       // @ts-ignore forces a crash
       // eslint-disable-next-line no-undef
       crashOnLoad()
+    } else if (query.crashOnLoadInApi) {
+      // Request crashes but doesn't propagate to asyncData.
+      await fetch(`${$config.baseURL}/api`)
     }
 
     if (process.server) {

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -35,7 +35,6 @@ describe('Resolve Client Options', () => {
       integrations: {
         ExtraErrorData: {},
         ReportingObserver: {},
-        RewriteFrames: {},
       },
       lazy: false,
       logMockCalls: true,
@@ -72,7 +71,6 @@ describe('Resolve Client Options', () => {
       integrations: {
         ExtraErrorData: {},
         ReportingObserver: {},
-        RewriteFrames: {},
       },
       lazy: false,
       logMockCalls: true,

--- a/test/typescript.test.ts
+++ b/test/typescript.test.ts
@@ -4,7 +4,10 @@ import { dirname } from 'path'
 import { describe, afterAll, beforeAll, beforeEach, test, expect } from 'vitest'
 import type { Browser } from 'playwright-chromium'
 import sentryTestkit from 'sentry-testkit'
-import { setup, url } from '@nuxtjs/module-test-utils'
+// TODO: Until sentry-kit types are fixed
+import type { Stacktrace } from '@sentry/node'
+import type { NuxtConfig } from '@nuxt/types'
+import { generatePort, setup, url } from '@nuxtjs/module-test-utils'
 import type { Nuxt } from '../src/kit-shim'
 import { $$, createBrowser, loadConfig } from './utils'
 
@@ -20,8 +23,15 @@ describe('Smoke test (typescript)', () => {
 
   beforeAll(async () => {
     await localServer.start(TEST_DSN)
-    const dsn = localServer.getDsn()
-    nuxt = (await setup(loadConfig(__dirname, 'typescript', { sentry: { dsn } }, { merge: true }))).nuxt
+    const dsn = localServer.getDsn()!
+    const port = await generatePort()
+    const overrides: NuxtConfig = {
+      sentry: { dsn },
+      server: { port },
+      publicRuntimeConfig: { baseURL: url('') },
+    }
+    const config = loadConfig(__dirname, 'typescript', overrides, { merge: true })
+    nuxt = (await setup(config)).nuxt
     browser = await createBrowser()
   })
 
@@ -62,6 +72,23 @@ describe('Smoke test (typescript)', () => {
     // Coming from `serverConfig` file-based configuration
     expect(reports[0].extra).toBeDefined()
     expect(reports[0].extra!.foo).toBe('1')
+  })
+
+  test('catches a server crash in server middleware', async () => {
+    const page = await browser.newPage()
+    const response = await page.goto(url('/?crashOnLoadInApi=1'))
+    expect(response!.status()).toBe(200)
+
+    const reports = testkit.reports()
+    expect(reports).toHaveLength(1)
+    expect(reports[0].error?.message).toContain('apiCrash is not defined')
+    expect(reports[0].error?.stacktrace as Stacktrace).toMatchObject({
+      frames: expect.arrayContaining([
+        expect.objectContaining({
+          filename: 'app:///api/index.ts',
+        }),
+      ]),
+    })
   })
 
   test('catches a client crash', async () => {


### PR DESCRIPTION
After manually inspecting some crashes I've realized that the `RewriteFrames` integration that the module enables by default does more harm than good.

In case there are source maps it doesn't really make any difference since stack frame paths are resolved from source maps then.

In case there are no source maps (for example when crash is within the server code and not inside the webpack context) then what `RewriteFrames` does is it [strips the whole path leaving just the file name](https://github.com/getsentry/sentry-javascript/blob/45692f4e80c49bf8aca77695e12313ee24ca8bae/packages/integrations/src/rewriteframes.ts#L83-L83). That can result in just `index.js` being shown, for example, which makes it unclear which file is being referred to.

To fix that, set `root` option on the server so that the paths are resolved relative to Nuxt's `rootDir`.

Also don't enable `RewriteFrames` integration on the client since it doesn't seem to be useful there. It only does something when the stack frame path is a local file path and on the client-side I don't see this being the case.