### PR TITLE
fix: make it possible to disable internal SDK integrations

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,5 @@
+const tsParser = require('@typescript-eslint/parser')
+
 module.exports = {
   extends: [
     '@nuxtjs/eslint-config',
@@ -15,6 +17,19 @@ module.exports = {
     'vue/multi-word-component-names': 'off',
   },
   overrides: [
+    {
+      files: ['*.vue'],
+      parserOptions: {
+        parser: {
+          // Overrides script parser for `<script lang="ts">`
+          ts: tsParser,
+        },
+      },
+      rules: {
+        'no-undef': 'off',
+        'no-unused-vars': 'off',
+      },
+    },
     {
       files: ['*.ts', '*.tsx'],
       extends: [

--- a/test/default.test.ts
+++ b/test/default.test.ts
@@ -20,7 +20,7 @@ describe('Smoke test (default)', () => {
 
   beforeAll(async () => {
     await localServer.start(TEST_DSN)
-    const dsn = localServer.getDsn()
+    const dsn = localServer.getDsn() ?? undefined
     nuxt = (await setup(loadConfig(__dirname, 'default', { sentry: { dsn } }, { merge: true }))).nuxt
     browser = await createBrowser()
   })

--- a/test/fixture/typescript/nuxt.config.ts
+++ b/test/fixture/typescript/nuxt.config.ts
@@ -28,6 +28,10 @@ const config: NuxtConfig = {
       // Integration from @Sentry/browser package.
       TryCatch: { eventTarget: false },
       Replay: {},
+      Dedupe: false,
+    },
+    serverIntegrations: {
+      Modules: false,
     },
     clientConfig: {
       // This sets the sample rate to be 10%. You may want this to be 100% while

--- a/test/fixture/typescript/pages/disabled-integrations.vue
+++ b/test/fixture/typescript/pages/disabled-integrations.vue
@@ -1,0 +1,38 @@
+<template>
+  <div>
+    <p>Integrations</p>
+    <p id="client">
+      Dedupe: {{ clientDedupeDisabled ? 'DISABLED' : 'ENABLED' }}
+    </p>
+    <p id="server">
+      Modules: {{ serverModulesDisabled ? 'DISABLED' : 'ENABLED' }}
+    </p>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import type { BrowserClient } from '@sentry/browser'
+import type { NodeClient } from '@sentry/node'
+
+export default defineComponent({
+  asyncData ({ $sentry }) {
+    if (process.server) {
+      return {
+        serverModulesDisabled: $sentry.getCurrentHub().getClient<NodeClient>()!.getIntegrationById('Modules') === undefined,
+      }
+    }
+  },
+  data () {
+    return {
+      clientDedupeDisabled: false,
+      serverModulesDisabled: false,
+    }
+  },
+  created () {
+    if (process.client) {
+      this.clientDedupeDisabled = this.$sentry.getCurrentHub().getClient<BrowserClient>()!.getIntegrationById('Dedupe') === undefined
+    }
+  },
+})
+</script>

--- a/test/lazy.test.ts
+++ b/test/lazy.test.ts
@@ -10,7 +10,7 @@ import { $$, createBrowser, loadConfig } from './utils'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
-const { testkit, localServer } = sentryTestkit.default()
+const { localServer } = sentryTestkit.default()
 const TEST_DSN = 'http://acacaeaccacacacabcaacdacdacadaca@sentry.io/000001'
 
 describe('Smoke test (lazy)', () => {
@@ -19,7 +19,7 @@ describe('Smoke test (lazy)', () => {
 
   beforeAll(async () => {
     await localServer.start(TEST_DSN)
-    const dsn = localServer.getDsn()
+    const dsn = localServer.getDsn() ?? undefined
     nuxt = (await setup(loadConfig(__dirname, 'lazy', { sentry: { dsn } }, { merge: true }))).nuxt
     browser = await createBrowser()
   })

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { describe, test, expect } from 'vitest'
 import { defu } from 'defu'
 import { ResolvedClientOptions, ResolvedServerOptions, resolveClientOptions, resolveServerOptions } from '../src/options'
@@ -115,7 +116,10 @@ describe('Resolve Server Options', () => {
       logMockCalls: true,
       tracing: false,
     })
-    const integrations = Array.isArray(resolvedOptions.config.integrations) ? resolvedOptions.config.integrations : null
+    expect(resolvedOptions.config.integrations).not.toBeUndefined()
+    const integrations = Array.isArray(resolvedOptions.config.integrations)
+      ? resolvedOptions.config.integrations
+      : resolvedOptions.config.integrations!([])
     expect(integrations).toBeTruthy()
     expect(integrations?.map(integration => integration.name)).toEqual(expect.arrayContaining(['Dedupe', 'ExtraErrorData', 'RewriteFrames', 'Transaction']))
   })
@@ -158,7 +162,10 @@ describe('Resolve Server Options', () => {
         },
       },
     })
-    const integrations = Array.isArray(resolvedOptions.config.integrations) ? resolvedOptions.config.integrations : null
+    expect(resolvedOptions.config.integrations).not.toBeUndefined()
+    const integrations = Array.isArray(resolvedOptions.config.integrations)
+      ? resolvedOptions.config.integrations
+      : resolvedOptions.config.integrations!([])
     expect(integrations).toBeTruthy()
     expect(integrations?.map(integration => integration.name)).toEqual(expect.arrayContaining(['Http', 'Dedupe', 'ExtraErrorData', 'RewriteFrames', 'Transaction']))
   })

--- a/test/typescript.test.ts
+++ b/test/typescript.test.ts
@@ -4,8 +4,6 @@ import { dirname } from 'path'
 import { describe, afterAll, beforeAll, beforeEach, test, expect } from 'vitest'
 import type { Browser } from 'playwright-chromium'
 import sentryTestkit from 'sentry-testkit'
-// TODO: Until sentry-kit types are fixed
-import type { Stacktrace } from '@sentry/node'
 import type { NuxtConfig } from '@nuxt/types'
 import { generatePort, setup, url } from '@nuxtjs/module-test-utils'
 import type { Nuxt } from '../src/kit-shim'
@@ -82,7 +80,7 @@ describe('Smoke test (typescript)', () => {
     const reports = testkit.reports()
     expect(reports).toHaveLength(1)
     expect(reports[0].error?.message).toContain('apiCrash is not defined')
-    expect(reports[0].error?.stacktrace as Stacktrace).toMatchObject({
+    expect(reports[0].error?.stacktrace).toMatchObject({
       frames: expect.arrayContaining([
         expect.objectContaining({
           filename: 'app:///api/index.ts',
@@ -100,6 +98,19 @@ describe('Smoke test (typescript)', () => {
     const reports = testkit.reports()
     expect(reports).toHaveLength(1)
     expect(reports[0].error?.message).toContain('crash_me is not a function')
+  })
+
+  test('can disable integrations that SDK enables by default', async () => {
+    const page = await browser.newPage()
+    await page.goto(url('/disabled-integrations'))
+
+    const clientParagraph = await $$('#client', page)
+    expect(clientParagraph).not.toBeNull()
+    expect(clientParagraph!.trim()).toBe('Dedupe: DISABLED')
+
+    const serverParagraph = await $$('#server', page)
+    expect(serverParagraph).not.toBeNull()
+    expect(serverParagraph!.trim()).toBe('Modules: DISABLED')
   })
 
   // TODO: Add tests for custom integration. Blocked by various sentry-kit bugs reported in its repo.

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -2,6 +2,7 @@ import { fileURLToPath } from 'node:url'
 import initJiti from 'jiti'
 import { defu } from 'defu'
 import { join } from 'pathe'
+import { NuxtConfig } from '@nuxt/types'
 import { chromium, Browser, Page } from 'playwright-chromium'
 
 const jitiImport = initJiti(fileURLToPath(import.meta.url))
@@ -22,7 +23,7 @@ export async function $$ (selector: string, page: Page): Promise<string | null> 
   return null
 }
 
-export function loadConfig (dir: string, fixture: string | null = null, override: Record<string, unknown> = {}, { merge = false } = {}): Record<string, unknown> {
+export function loadConfig (dir: string, fixture: string | null = null, override: NuxtConfig = {}, { merge = false } = {}): NuxtConfig {
   const fixtureConfig = jitiImport(join(dir, 'fixture', fixture ?? '', 'nuxt.config'))
   const config = Object.assign({}, fixtureConfig.default || fixtureConfig)
 

--- a/test/with-lazy-config.test.ts
+++ b/test/with-lazy-config.test.ts
@@ -19,7 +19,7 @@ describe('Smoke test (lazy config)', () => {
 
   beforeAll(async () => {
     await localServer.start(TEST_DSN)
-    const dsn = localServer.getDsn()
+    const dsn = localServer.getDsn() ?? undefined
     nuxt = (await setup(loadConfig(__dirname, 'with-lazy-config', { sentry: { dsn } }, { merge: true }))).nuxt
     browser = await createBrowser()
   })


### PR DESCRIPTION
It wasn't possible to disable internal SDK integrations that SDK enables by default (for example `Modules` on the server and `Dedupe` on the client).